### PR TITLE
Add authentication and registration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Tablero de Puntuaciones (PHP + MySQL + Bootstrap) — COMPLETO (estudiantes + re
 2) Copie la carpeta 'tablero_puntuaciones_full' a htdocs (XAMPP).
 3) Ajuste credenciales en includes/db.php si es necesario.
 4) Abra: http://localhost/tablero_puntuaciones_full/
+5) Registre la primera cuenta de administrador desde registro.php y úsela para iniciar sesión.
 
 Flujo:
 - Cree una ACTIVIDAD en actividades.php.
@@ -17,6 +18,7 @@ Flujo:
 - En "Habilidades" agregue/edite habilidades si lo necesita.
 - En "Abrir tablero" verá tarjetas de estudiantes con su total de puntos.
 - Botón "Puntuar" permite +1/-1 por habilidad para el estudiante.
+- Use el menú superior para cerrar sesión cuando termine.
 
 Notas:
 - Los retos son informativos en el tablero en esta versión. Si desea que otorguen puntos y se marquen por estudiante (completado/no completado), se puede añadir fácilmente con una tabla 'retos_estudiantes' y una columna 'puntos' en retos.

--- a/README.txt
+++ b/README.txt
@@ -8,6 +8,7 @@ Tablero de Puntuaciones (PHP + MySQL + Bootstrap) — COMPLETO (estudiantes + re
 2) Copie la carpeta 'tablero_puntuaciones_full' a htdocs (XAMPP).
 3) Ajuste credenciales en includes/db.php si es necesario.
 4) Abra: http://localhost/tablero_puntuaciones_full/
+5) Registre la primera cuenta de administrador desde registro.php y úsela para iniciar sesión.
 
 Flujo:
 - Cree una ACTIVIDAD en actividades.php.
@@ -16,6 +17,7 @@ Flujo:
 - En "Habilidades" agregue/edite habilidades si lo necesita.
 - En "Abrir tablero" verá tarjetas de estudiantes con su total de puntos.
 - Botón "Puntuar" permite +1/-1 por habilidad para el estudiante.
+- Use el menú superior para cerrar sesión cuando termine.
 
 Notas:
 - Los retos son informativos en el tablero en esta versión. Si desea que otorguen puntos y se marquen por estudiante (completado/no completado), se puede añadir fácilmente con una tabla 'retos_estudiantes' y una columna 'puntos' en retos.

--- a/actividades.php
+++ b/actividades.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 // Crear actividad

--- a/estudiantes.php
+++ b/estudiantes.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;

--- a/habilidades.php
+++ b/habilidades.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['nombre'])) {

--- a/includes/header.php
+++ b/includes/header.php
@@ -1,4 +1,10 @@
-<?php ?>
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$usuario_actual = $_SESSION['user_name'] ?? null;
+?>
 <!doctype html>
 <html lang="es">
 <head>
@@ -16,9 +22,24 @@
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-      <ul class="navbar-nav">
-        <li class="nav-item"><a class="nav-link" href="actividades.php">Actividades</a></li>
-        <li class="nav-item"><a class="nav-link" href="habilidades.php">Habilidades / Insignias</a></li>
+      <ul class="navbar-nav me-auto">
+        <?php if ($usuario_actual): ?>
+          <li class="nav-item"><a class="nav-link" href="actividades.php">Actividades</a></li>
+          <li class="nav-item"><a class="nav-link" href="habilidades.php">Habilidades / Insignias</a></li>
+        <?php endif; ?>
+      </ul>
+      <ul class="navbar-nav ms-auto">
+        <?php if ($usuario_actual): ?>
+          <li class="nav-item">
+            <span class="navbar-text me-2">👋 <?= htmlspecialchars($usuario_actual) ?></span>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="logout.php">Cerrar sesión</a>
+          </li>
+        <?php else: ?>
+          <li class="nav-item"><a class="nav-link" href="login.php">Iniciar sesión</a></li>
+          <li class="nav-item"><a class="nav-link" href="registro.php">Registrarse</a></li>
+        <?php endif; ?>
       </ul>
     </div>
   </div>

--- a/includes/protect.php
+++ b/includes/protect.php
@@ -1,0 +1,9 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (empty($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}

--- a/index.php
+++ b/index.php
@@ -1,3 +1,9 @@
 <?php
-header("Location: actividades.php");
+session_start();
+
+if (isset($_SESSION['user_id'])) {
+    header("Location: actividades.php");
+} else {
+    header("Location: login.php");
+}
 exit;

--- a/login.php
+++ b/login.php
@@ -1,0 +1,77 @@
+<?php
+require_once 'includes/db.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!empty($_SESSION['user_id'])) {
+    header('Location: actividades.php');
+    exit;
+}
+
+$errores = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($email === '' || $password === '') {
+        $errores[] = 'Por favor ingresa tu correo y contraseña.';
+    } else {
+        $stmt = $conn->prepare('SELECT id, nombre, password FROM usuarios WHERE email = ? LIMIT 1');
+        $stmt->bind_param('s', $email);
+        $stmt->execute();
+        $resultado = $stmt->get_result();
+        $usuario = $resultado->fetch_assoc();
+
+        if ($usuario && password_verify($password, $usuario['password'])) {
+            $_SESSION['user_id'] = $usuario['id'];
+            $_SESSION['user_name'] = $usuario['nombre'];
+            header('Location: actividades.php');
+            exit;
+        }
+
+        $errores[] = 'Credenciales incorrectas. Inténtalo nuevamente.';
+    }
+}
+
+include 'includes/header.php';
+?>
+
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-5">
+    <h3 class="mb-3 text-center">Iniciar sesión</h3>
+    <p class="text-muted text-center">Gestiona tus actividades ingresando con tu cuenta.</p>
+
+    <?php if ($errores): ?>
+      <div class="alert alert-danger">
+        <ul class="mb-0">
+          <?php foreach ($errores as $error): ?>
+            <li><?= htmlspecialchars($error) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+    <?php endif; ?>
+
+    <form method="post" class="card card-body shadow-sm">
+      <div class="mb-3">
+        <label for="email" class="form-label">Correo electrónico</label>
+        <input type="email" class="form-control" id="email" name="email" required value="<?= htmlspecialchars($_POST['email'] ?? '') ?>">
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Contraseña</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-primary">Entrar</button>
+      </div>
+    </form>
+
+    <div class="text-center mt-3">
+      <span class="text-muted">¿Aún no tienes cuenta?</span> <a href="registro.php">Regístrate aquí</a>.
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+
+header('Location: login.php');
+exit;

--- a/puntuar.php
+++ b/puntuar.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;

--- a/puntuar_estudiante.php
+++ b/puntuar_estudiante.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 $estudiante_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;

--- a/registro.php
+++ b/registro.php
@@ -1,0 +1,103 @@
+<?php
+require_once 'includes/db.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!empty($_SESSION['user_id'])) {
+    header('Location: actividades.php');
+    exit;
+}
+
+$errores = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $nombre = trim($_POST['nombre'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $confirmar = $_POST['confirmar'] ?? '';
+
+    if ($nombre === '' || $email === '' || $password === '') {
+        $errores[] = 'Todos los campos son obligatorios.';
+    }
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errores[] = 'El correo electrónico no es válido.';
+    }
+
+    if ($password !== $confirmar) {
+        $errores[] = 'Las contraseñas no coinciden.';
+    }
+
+    if (!$errores) {
+        $stmt = $conn->prepare('SELECT id FROM usuarios WHERE email = ? LIMIT 1');
+        $stmt->bind_param('s', $email);
+        $stmt->execute();
+        $stmt->store_result();
+
+        if ($stmt->num_rows > 0) {
+            $errores[] = 'Ya existe una cuenta con ese correo electrónico.';
+        } else {
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $stmtInsert = $conn->prepare('INSERT INTO usuarios (nombre, email, password) VALUES (?, ?, ?)');
+            $stmtInsert->bind_param('sss', $nombre, $email, $hash);
+            if ($stmtInsert->execute()) {
+                $_SESSION['user_id'] = $stmtInsert->insert_id;
+                $_SESSION['user_name'] = $nombre;
+                header('Location: actividades.php');
+                exit;
+            } else {
+                $errores[] = 'Ocurrió un error al registrar la cuenta. Intenta nuevamente.';
+            }
+        }
+    }
+}
+
+include 'includes/header.php';
+?>
+
+<div class="row justify-content-center">
+  <div class="col-md-6 col-lg-5">
+    <h3 class="mb-3 text-center">Crear una cuenta</h3>
+    <p class="text-muted text-center">Registra a los administradores del tablero para proteger tus datos.</p>
+
+    <?php if ($errores): ?>
+      <div class="alert alert-danger">
+        <ul class="mb-0">
+          <?php foreach ($errores as $error): ?>
+            <li><?= htmlspecialchars($error) ?></li>
+          <?php endforeach; ?>
+        </ul>
+      </div>
+    <?php endif; ?>
+
+    <form method="post" class="card card-body shadow-sm">
+      <div class="mb-3">
+        <label for="nombre" class="form-label">Nombre</label>
+        <input type="text" class="form-control" id="nombre" name="nombre" required value="<?= htmlspecialchars($_POST['nombre'] ?? '') ?>">
+      </div>
+      <div class="mb-3">
+        <label for="email" class="form-label">Correo electrónico</label>
+        <input type="email" class="form-control" id="email" name="email" required value="<?= htmlspecialchars($_POST['email'] ?? '') ?>">
+      </div>
+      <div class="mb-3">
+        <label for="password" class="form-label">Contraseña</label>
+        <input type="password" class="form-control" id="password" name="password" required>
+      </div>
+      <div class="mb-3">
+        <label for="confirmar" class="form-label">Confirmar contraseña</label>
+        <input type="password" class="form-control" id="confirmar" name="confirmar" required>
+      </div>
+      <div class="d-grid">
+        <button type="submit" class="btn btn-success">Registrarme</button>
+      </div>
+    </form>
+
+    <div class="text-center mt-3">
+      <span class="text-muted">¿Ya tienes una cuenta?</span> <a href="login.php">Inicia sesión</a>.
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/retos.php
+++ b/retos.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 include 'includes/header.php';
 
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -2,6 +2,15 @@
 CREATE DATABASE IF NOT EXISTS tablero_puntuaciones CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE tablero_puntuaciones;
 
+-- Usuarios administradores del tablero
+CREATE TABLE IF NOT EXISTS usuarios (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(120) NOT NULL,
+  email VARCHAR(150) NOT NULL UNIQUE,
+  password VARCHAR(255) NOT NULL,
+  creado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
 -- Actividades
 CREATE TABLE IF NOT EXISTS actividades (
   id INT AUTO_INCREMENT PRIMARY KEY,

--- a/update_puntaje.php
+++ b/update_puntaje.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'includes/db.php';
+require_once 'includes/protect.php';
 
 $estudiante = isset($_GET['estudiante']) ? (int)$_GET['estudiante'] : 0;
 $habilidad = isset($_GET['habilidad']) ? (int)$_GET['habilidad'] : 0;


### PR DESCRIPTION
## Summary
- add login, registration and logout flows secured with password hashing and sessions
- protect administrative pages with a reusable authentication guard and update the navigation for session-aware links
- extend the database schema and documentation to include administrator accounts

## Testing
- php -l index.php login.php registro.php logout.php includes/protect.php includes/header.php actividades.php estudiantes.php habilidades.php retos.php puntuar.php puntuar_estudiante.php update_puntaje.php

------
https://chatgpt.com/codex/tasks/task_e_68d4b30eb90c83269fa6bf3fdba65faf