### PR TITLE
Agregar adjuntos multimedia y vista detallada para retos

### DIFF
--- a/reto_detalle.php
+++ b/reto_detalle.php
@@ -1,0 +1,82 @@
+<?php
+require_once 'includes/db.php';
+require_once 'includes/protect.php';
+include 'includes/header.php';
+
+function obtenerEmbedYoutube(?string $url): ?string {
+    if (!$url) {
+        return null;
+    }
+    $patron = '/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/|v\/))([A-Za-z0-9_-]{11})/';
+    if (preg_match($patron, $url, $coincidencias)) {
+        return 'https://www.youtube.com/embed/'.$coincidencias[1];
+    }
+    return null;
+}
+
+$reto_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($reto_id <= 0) {
+    echo "<div class='alert alert-danger'>Reto no válido.</div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$stmt = $conn->prepare("SELECT r.id, r.nombre, r.descripcion, r.imagen, r.video_url, r.pdf, a.id AS actividad_id, a.nombre AS actividad_nombre FROM retos r INNER JOIN actividades a ON r.actividad_id = a.id WHERE r.id = ?");
+$stmt->bind_param("i", $reto_id);
+$stmt->execute();
+$reto = $stmt->get_result()->fetch_assoc();
+
+if (!$reto) {
+    echo "<div class='alert alert-danger'>Reto no encontrado.</div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
+?>
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <div>
+    <h3 class="mb-1"><?= htmlspecialchars($reto['nombre']) ?></h3>
+    <p class="text-muted mb-0">Actividad: <a href="retos.php?actividad_id=<?= $reto['actividad_id'] ?>"><?= htmlspecialchars($reto['actividad_nombre']) ?></a></p>
+  </div>
+  <a href="retos.php?actividad_id=<?= $reto['actividad_id'] ?>" class="btn btn-outline-secondary">Volver</a>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">Descripción</h5>
+    <p class="card-text"><?= nl2br(htmlspecialchars($reto['descripcion'] ?? '')) ?: '<span class="text-muted">Sin descripción</span>' ?></p>
+
+    <?php if (!empty($reto['imagen'])): ?>
+      <div class="mt-4">
+        <h5>Imagen</h5>
+        <img src="<?= htmlspecialchars($reto['imagen']) ?>" alt="Imagen del reto" class="img-fluid rounded border">
+      </div>
+    <?php endif; ?>
+
+    <?php if ($video_embed || !empty($reto['video_url'])): ?>
+      <div class="mt-4">
+        <h5>Video</h5>
+        <?php if ($video_embed): ?>
+          <div class="ratio ratio-16x9">
+            <iframe src="<?= htmlspecialchars($video_embed) ?>" title="Video del reto" allowfullscreen></iframe>
+          </div>
+        <?php else: ?>
+          <a href="<?= htmlspecialchars($reto['video_url']) ?>" target="_blank" rel="noopener">Ver video</a>
+        <?php endif; ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if (!empty($reto['pdf'])): ?>
+      <div class="mt-4">
+        <h5>Documento PDF</h5>
+        <a href="<?= htmlspecialchars($reto['pdf']) ?>" class="btn btn-outline-secondary mb-3" target="_blank" rel="noopener">Abrir PDF</a>
+        <div class="ratio ratio-16x9">
+          <iframe src="<?= htmlspecialchars($reto['pdf']) ?>" title="PDF del reto"></iframe>
+        </div>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/retos.php
+++ b/retos.php
@@ -3,6 +3,40 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
+function subirArchivo(string $campo, array $extensionesPermitidas): ?string {
+  if (!isset($_FILES[$campo]) || !is_array($_FILES[$campo])) {
+    return null;
+  }
+
+  $archivo = $_FILES[$campo];
+  $error = $archivo['error'] ?? UPLOAD_ERR_NO_FILE;
+  if ($error === UPLOAD_ERR_NO_FILE) {
+    return null;
+  }
+  if ($error !== UPLOAD_ERR_OK) {
+    return null;
+  }
+
+  $extension = strtolower(pathinfo($archivo['name'] ?? '', PATHINFO_EXTENSION));
+  if ($extension === '' || !in_array($extension, $extensionesPermitidas, true)) {
+    return null;
+  }
+
+  $rutaDirectorio = __DIR__.'/assets/uploads/retos';
+  if (!is_dir($rutaDirectorio)) {
+    mkdir($rutaDirectorio, 0775, true);
+  }
+
+  $nombreArchivo = uniqid('reto_', true).'.'.$extension;
+  $rutaDestino = $rutaDirectorio.'/'.$nombreArchivo;
+
+  if (!move_uploaded_file($archivo['tmp_name'] ?? '', $rutaDestino)) {
+    return null;
+  }
+
+  return 'assets/uploads/retos/'.$nombreArchivo;
+}
+
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;
 if ($actividad_id <= 0) { echo "<div class='alert alert-danger'>Actividad no valida.</div>"; include 'includes/footer.php'; exit; }
 
@@ -17,9 +51,20 @@ if (!$actividad) { echo "<div class='alert alert-danger'>Actividad no encontrada
 if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['nombre'])) {
   $nombre = trim($_POST['nombre']);
   $descripcion = trim($_POST['descripcion'] ?? '');
+  $video_url = trim($_POST['video_url'] ?? '');
+  $imagen = subirArchivo('imagen', ['jpg', 'jpeg', 'png', 'gif']);
+  $pdf = subirArchivo('pdf', ['pdf']);
+
+  if ($video_url !== '' && !preg_match('/^https?:\/\//i', $video_url)) {
+    $video_url = 'https://'.$video_url;
+  }
+  if ($video_url === '') {
+    $video_url = null;
+  }
+
   if ($nombre !== '') {
-    $stmt = $conn->prepare("INSERT INTO retos (actividad_id, nombre, descripcion) VALUES (?, ?, ?)");
-    $stmt->bind_param("iss", $actividad_id, $nombre, $descripcion);
+    $stmt = $conn->prepare("INSERT INTO retos (actividad_id, nombre, descripcion, imagen, video_url, pdf) VALUES (?, ?, ?, ?, ?, ?)");
+    $stmt->bind_param("isssss", $actividad_id, $nombre, $descripcion, $imagen, $video_url, $pdf);
     $stmt->execute();
   }
   header("Location: retos.php?actividad_id=".$actividad_id); exit;
@@ -28,11 +73,27 @@ if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['nombre'])) {
 // Eliminar reto
 if (isset($_GET['eliminar'])) {
   $id = (int)$_GET['eliminar'];
-  $conn->query("DELETE FROM retos WHERE id=$id AND actividad_id=$actividad_id");
+  $stmt = $conn->prepare("SELECT imagen, pdf FROM retos WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $id, $actividad_id);
+  $stmt->execute();
+  if ($registro = $stmt->get_result()->fetch_assoc()) {
+    foreach (['imagen', 'pdf'] as $campo) {
+      if (!empty($registro[$campo])) {
+        $ruta = __DIR__.'/'.$registro[$campo];
+        if (is_file($ruta)) {
+          unlink($ruta);
+        }
+      }
+    }
+  }
+
+  $stmt = $conn->prepare("DELETE FROM retos WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $id, $actividad_id);
+  $stmt->execute();
   header("Location: retos.php?actividad_id=".$actividad_id); exit;
 }
 
-$res = $conn->prepare("SELECT id, nombre, descripcion FROM retos WHERE actividad_id=? ORDER BY id DESC");
+$res = $conn->prepare("SELECT id, nombre, descripcion, imagen, video_url, pdf FROM retos WHERE actividad_id=? ORDER BY id DESC");
 $res->bind_param("i", $actividad_id);
 $res->execute();
 $retos = $res->get_result();
@@ -42,27 +103,43 @@ $retos = $res->get_result();
   <a href="actividades.php" class="btn btn-outline-secondary">Volver</a>
 </div>
 
-<form method="post" class="row g-3 mb-4">
+<form method="post" class="row g-3 mb-4" enctype="multipart/form-data">
   <div class="col-md-4">
     <input type="text" name="nombre" class="form-control" placeholder="Nombre del reto" required>
   </div>
-  <div class="col-md-6">
+  <div class="col-md-4">
     <input type="text" name="descripcion" class="form-control" placeholder="Descripción (opcional)">
   </div>
-  <div class="col-md-2 d-grid">
+  <div class="col-md-4">
+    <input type="url" name="video_url" class="form-control" placeholder="URL de video de YouTube (opcional)">
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Imagen (opcional)</label>
+    <input type="file" name="imagen" class="form-control" accept="image/*">
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Archivo PDF (opcional)</label>
+    <input type="file" name="pdf" class="form-control" accept="application/pdf">
+  </div>
+  <div class="col-md-4 d-grid align-content-end">
     <button class="btn btn-primary">Agregar reto</button>
   </div>
 </form>
 
 <div class="table-responsive">
 <table class="table table-striped align-middle">
-  <thead><tr><th>#</th><th>Nombre</th><th>Descripción</th><th>Acciones</th></tr></thead>
+  <thead><tr><th>#</th><th>Nombre</th><th>Descripción</th><th>Adjuntos</th><th>Acciones</th></tr></thead>
   <tbody>
     <?php while($r = $retos->fetch_assoc()): ?>
       <tr>
         <td><?= $r['id'] ?></td>
-        <td><?= htmlspecialchars($r['nombre']) ?></td>
+        <td><a href="reto_detalle.php?id=<?= $r['id'] ?>" class="text-decoration-none"><?= htmlspecialchars($r['nombre']) ?></a></td>
         <td><?= htmlspecialchars($r['descripcion']) ?></td>
+        <td>
+          <?php if(!empty($r['imagen'])): ?><span class="badge bg-info me-1">Imagen</span><?php endif; ?>
+          <?php if(!empty($r['video_url'])): ?><span class="badge bg-danger me-1">Video</span><?php endif; ?>
+          <?php if(!empty($r['pdf'])): ?><span class="badge bg-secondary">PDF</span><?php endif; ?>
+        </td>
         <td>
           <a class="btn btn-sm btn-danger" href="retos.php?actividad_id=<?= $actividad_id ?>&eliminar=<?= $r['id'] ?>" onclick="return confirm('¿Eliminar reto?');">Eliminar</a>
         </td>

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -50,6 +50,9 @@ CREATE TABLE IF NOT EXISTS retos (
   actividad_id INT NOT NULL,
   nombre VARCHAR(150) NOT NULL,
   descripcion TEXT,
+  imagen VARCHAR(255),
+  video_url VARCHAR(255),
+  pdf VARCHAR(255),
   CONSTRAINT fk_reto_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
## Summary
- permitir adjuntar imágenes, videos de YouTube y PDF al crear retos
- mostrar indicadores de adjuntos y enlazar a una nueva página de detalle por reto
- ampliar el esquema de la tabla de retos para almacenar las nuevas referencias de archivos

## Testing
- php -l retos.php
- php -l reto_detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68d4bbf77c788326af87f5a509a55fc1