### PR TITLE
Permitir edición de entidades y mostrar retos como tarjetas con iconos

### DIFF
--- a/actividades.php
+++ b/actividades.php
@@ -3,14 +3,23 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
-// Crear actividad
+// Crear / actualizar actividad
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['nombre'])) {
   $nombre = trim($_POST['nombre']);
+  $actividad_id = isset($_POST['actividad_id']) ? (int)$_POST['actividad_id'] : 0;
+
   if ($nombre !== '') {
-    $stmt = $conn->prepare("INSERT INTO actividades (nombre) VALUES (?)");
-    $stmt->bind_param("s", $nombre);
-    $stmt->execute();
+    if ($actividad_id > 0) {
+      $stmt = $conn->prepare("UPDATE actividades SET nombre=? WHERE id=?");
+      $stmt->bind_param("si", $nombre, $actividad_id);
+      $stmt->execute();
+    } else {
+      $stmt = $conn->prepare("INSERT INTO actividades (nombre) VALUES (?)");
+      $stmt->bind_param("s", $nombre);
+      $stmt->execute();
+    }
   }
+
   header("Location: actividades.php"); exit;
 }
 
@@ -21,6 +30,15 @@ if (isset($_GET['eliminar'])) {
   header("Location: actividades.php"); exit;
 }
 
+$actividadEditar = null;
+if (isset($_GET['editar'])) {
+  $editar_id = (int)$_GET['editar'];
+  $stmt = $conn->prepare("SELECT id, nombre FROM actividades WHERE id=?");
+  $stmt->bind_param("i", $editar_id);
+  $stmt->execute();
+  $actividadEditar = $stmt->get_result()->fetch_assoc();
+}
+
 $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY id DESC");
 ?>
 <div class="d-flex align-items-center justify-content-between mb-3">
@@ -28,13 +46,18 @@ $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY
 </div>
 
 <form method="post" class="row g-3 mb-4">
+  <input type="hidden" name="actividad_id" value="<?= $actividadEditar['id'] ?? 0 ?>">
   <div class="col-md-8">
-    <input type="text" name="nombre" class="form-control" placeholder="Nombre de la actividad" required>
+    <input type="text" name="nombre" class="form-control" placeholder="Nombre de la actividad" value="<?= htmlspecialchars($actividadEditar['nombre'] ?? '') ?>" required>
   </div>
   <div class="col-md-4 d-grid">
-    <button class="btn btn-primary">Crear actividad</button>
+    <button class="btn btn-primary"><?= $actividadEditar ? 'Actualizar actividad' : 'Crear actividad' ?></button>
   </div>
 </form>
+
+<?php if ($actividadEditar): ?>
+  <div class="alert alert-info">Editando la actividad "<?= htmlspecialchars($actividadEditar['nombre']) ?>". <a href="actividades.php">Cancelar edición</a></div>
+<?php endif; ?>
 
 <div class="table-responsive">
 <table class="table table-striped align-middle">
@@ -56,7 +79,10 @@ $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY
       <td><a class="btn btn-outline-secondary btn-sm" href="estudiantes.php?actividad_id=<?= $a['id'] ?>">Gestionar</a></td>
       <td><a class="btn btn-outline-primary btn-sm" href="retos.php?actividad_id=<?= $a['id'] ?>">Retos</a></td>
       <td><a class="btn btn-success btn-sm" href="puntuar.php?actividad_id=<?= $a['id'] ?>">Abrir tablero</a></td>
-      <td><a class="btn btn-danger btn-sm" href="actividades.php?eliminar=<?= $a['id'] ?>" onclick="return confirm('¿Eliminar actividad y todo su contenido?');">Eliminar</a></td>
+      <td>
+        <a class="btn btn-sm btn-outline-secondary" href="actividades.php?editar=<?= $a['id'] ?>">Editar</a>
+        <a class="btn btn-danger btn-sm" href="actividades.php?eliminar=<?= $a['id'] ?>" onclick="return confirm('¿Eliminar actividad y todo su contenido?');">Eliminar</a>
+      </td>
     </tr>
     <?php endwhile; ?>
   </tbody>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,1 +1,13 @@
 .card .badge { font-size: 0.95rem; }
+
+.reto-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #f1f3f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.08);
+}

--- a/estudiantes.php
+++ b/estudiantes.php
@@ -3,6 +3,32 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
+function subirAvatar(string $campo): ?string {
+  if (!isset($_FILES[$campo]) || empty($_FILES[$campo]['name'])) {
+    return null;
+  }
+
+  $archivo = $_FILES[$campo];
+  if (($archivo['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
+    return null;
+  }
+
+  $ext = strtolower(pathinfo($archivo['name'], PATHINFO_EXTENSION));
+  if (!in_array($ext, ['jpg','jpeg','png','gif','webp'], true)) {
+    $ext = 'png';
+  }
+
+  $fname = 'avatar_' . time() . '_' . rand(1000,9999) . '.' . $ext;
+  $dest = 'assets/img/avatars/' . $fname;
+  if (is_uploaded_file($archivo['tmp_name'] ?? '') && move_uploaded_file($archivo['tmp_name'], $dest)) {
+    if (file_exists($dest)) {
+      return $fname;
+    }
+  }
+
+  return null;
+}
+
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;
 if ($actividad_id<=0) { echo "<div class='alert alert-danger'>Actividad no valida.</div>"; include 'includes/footer.php'; exit; }
 
@@ -16,22 +42,38 @@ if(!$actividad){ echo "<div class='alert alert-danger'>Actividad no encontrada.<
 // Agregar estudiante
 if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['crear_est'])){
   $nombre = trim($_POST['nombre']);
-  $avatar = 'default.png';
-  if(!empty($_FILES['avatar']['name'])){
-    $ext = strtolower(pathinfo($_FILES['avatar']['name'], PATHINFO_EXTENSION));
-    if (!in_array($ext, ['jpg','jpeg','png','gif','webp'])) { $ext = 'png'; }
-    $fname = 'avatar_' . time() . '_' . rand(1000,9999) . '.' . $ext;
-    $dest = 'assets/img/avatars/' . $fname;
-    if (is_uploaded_file($_FILES['avatar']['tmp_name'])) {
-      @move_uploaded_file($_FILES['avatar']['tmp_name'], $dest);
-      if (file_exists($dest)) { $avatar = $fname; }
-    }
-  }
+  $avatar = subirAvatar('avatar') ?? 'default.png';
   if($nombre!==''){
     $stmt = $conn->prepare("INSERT INTO estudiantes (nombre, avatar, actividad_id) VALUES (?, ?, ?)");
     $stmt->bind_param("ssi", $nombre, $avatar, $actividad_id);
     $stmt->execute();
   }
+  header("Location: estudiantes.php?actividad_id=".$actividad_id); exit;
+}
+
+// Editar estudiante
+if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['editar_est'])){
+  $estudiante_id = (int)$_POST['estudiante_id'];
+  $nombre = trim($_POST['nombre']);
+  $avatarActual = $_POST['avatar_actual'] ?? 'default.png';
+
+  if($estudiante_id>0 && $nombre!==''){
+    $nuevoAvatar = subirAvatar('avatar');
+    if ($nuevoAvatar) {
+      if ($avatarActual && $avatarActual !== 'default.png') {
+        $ruta = 'assets/img/avatars/'.$avatarActual;
+        if (file_exists($ruta)) {
+          @unlink($ruta);
+        }
+      }
+      $avatarActual = $nuevoAvatar;
+    }
+
+    $stmt = $conn->prepare("UPDATE estudiantes SET nombre=?, avatar=? WHERE id=? AND actividad_id=?");
+    $stmt->bind_param("ssii", $nombre, $avatarActual, $estudiante_id, $actividad_id);
+    $stmt->execute();
+  }
+
   header("Location: estudiantes.php?actividad_id=".$actividad_id); exit;
 }
 
@@ -60,6 +102,15 @@ $stmt=$conn->prepare($q);
 $stmt->bind_param("i",$actividad_id);
 $stmt->execute();
 $estudiantes=$stmt->get_result();
+
+$estudianteEditar = null;
+if (isset($_GET['editar'])) {
+  $editar_id = (int)$_GET['editar'];
+  $stmt = $conn->prepare("SELECT id, nombre, avatar FROM estudiantes WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $editar_id, $actividad_id);
+  $stmt->execute();
+  $estudianteEditar = $stmt->get_result()->fetch_assoc();
+}
 ?>
 <div class="d-flex align-items-center justify-content-between mb-3">
   <h3>Estudiantes - <?= htmlspecialchars($actividad['nombre']) ?></h3>
@@ -67,17 +118,30 @@ $estudiantes=$stmt->get_result();
 </div>
 
 <form method="post" enctype="multipart/form-data" class="row g-3 mb-4">
-  <input type="hidden" name="crear_est" value="1">
+  <?php if ($estudianteEditar): ?>
+    <input type="hidden" name="editar_est" value="1">
+    <input type="hidden" name="estudiante_id" value="<?= $estudianteEditar['id'] ?>">
+    <input type="hidden" name="avatar_actual" value="<?= htmlspecialchars($estudianteEditar['avatar']) ?>">
+  <?php else: ?>
+    <input type="hidden" name="crear_est" value="1">
+  <?php endif; ?>
   <div class="col-md-5">
-    <input type="text" name="nombre" class="form-control" placeholder="Nombre del estudiante" required>
+    <input type="text" name="nombre" class="form-control" placeholder="Nombre del estudiante" value="<?= htmlspecialchars($estudianteEditar['nombre'] ?? '') ?>" required>
   </div>
   <div class="col-md-5">
     <input type="file" name="avatar" class="form-control" accept="image/*">
+    <?php if ($estudianteEditar): ?>
+      <div class="form-text">Deja vacío para mantener el avatar actual.</div>
+    <?php endif; ?>
   </div>
   <div class="col-md-2 d-grid">
-    <button class="btn btn-primary">Agregar</button>
+    <button class="btn btn-primary"><?= $estudianteEditar ? 'Actualizar' : 'Agregar' ?></button>
   </div>
 </form>
+
+<?php if ($estudianteEditar): ?>
+  <div class="alert alert-info">Editando a <?= htmlspecialchars($estudianteEditar['nombre']) ?>. <a href="estudiantes.php?actividad_id=<?= $actividad_id ?>">Cancelar edición</a></div>
+<?php endif; ?>
 
 <table class="table table-striped align-middle">
   <thead><tr><th>Avatar</th><th>Nombre</th><th>Puntos</th><th>Acciones</th></tr></thead>
@@ -88,6 +152,7 @@ $estudiantes=$stmt->get_result();
         <td><?= htmlspecialchars($e['nombre']) ?></td>
         <td><span class="badge bg-success fs-6"><?= $e['total'] ?></span></td>
         <td>
+          <a class="btn btn-sm btn-outline-secondary" href="estudiantes.php?actividad_id=<?= $actividad_id ?>&editar=<?= $e['id'] ?>">Editar</a>
           <a class="btn btn-sm btn-success" href="puntuar_estudiante.php?id=<?= $e['id'] ?>">Puntuar</a>
           <a class="btn btn-sm btn-danger" href="estudiantes.php?actividad_id=<?= $actividad_id ?>&eliminar=<?= $e['id'] ?>" onclick="return confirm('¿Eliminar estudiante?');">Eliminar</a>
         </td>

--- a/puntuar.php
+++ b/puntuar.php
@@ -48,11 +48,14 @@ $estudiantes=$stmt->get_result();
     <?php else: ?>
       <ul class="list-group">
         <?php while($r=$retos->fetch_assoc()): ?>
-          <li class="list-group-item">
-            <strong><?= htmlspecialchars($r['nombre']) ?></strong>
-            <?php if(!empty($r['descripcion'])): ?>
-              <div class="small text-muted"><?= htmlspecialchars($r['descripcion']) ?></div>
-            <?php endif; ?>
+          <li class="list-group-item d-flex justify-content-between align-items-start">
+            <div class="me-3">
+              <strong><a href="reto_detalle.php?id=<?= $r['id'] ?>" class="text-decoration-none"><?= htmlspecialchars($r['nombre']) ?></a></strong>
+              <?php if(!empty($r['descripcion'])): ?>
+                <div class="small text-muted"><?= htmlspecialchars($r['descripcion']) ?></div>
+              <?php endif; ?>
+            </div>
+            <a class="btn btn-outline-primary btn-sm" href="reto_detalle.php?id=<?= $r['id'] ?>">Ver detalle</a>
           </li>
         <?php endwhile; ?>
       </ul>

--- a/reto_detalle.php
+++ b/reto_detalle.php
@@ -1,0 +1,93 @@
+<?php
+require_once 'includes/db.php';
+require_once 'includes/protect.php';
+include 'includes/header.php';
+
+$columnaIcono = $conn->query("SHOW COLUMNS FROM retos LIKE 'icono'");
+if ($columnaIcono && $columnaIcono->num_rows === 0) {
+    $conn->query("ALTER TABLE retos ADD COLUMN icono VARCHAR(10) DEFAULT '🎯' AFTER pdf");
+}
+if ($columnaIcono instanceof mysqli_result) {
+    $columnaIcono->free();
+}
+
+function obtenerEmbedYoutube(?string $url): ?string {
+    if (!$url) {
+        return null;
+    }
+    $patron = '/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/|v\/))([A-Za-z0-9_-]{11})/';
+    if (preg_match($patron, $url, $coincidencias)) {
+        return 'https://www.youtube.com/embed/'.$coincidencias[1];
+    }
+    return null;
+}
+
+$reto_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($reto_id <= 0) {
+    echo "<div class='alert alert-danger'>Reto no válido.</div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$stmt = $conn->prepare("SELECT r.id, r.nombre, r.descripcion, r.imagen, r.video_url, r.pdf, r.icono, a.id AS actividad_id, a.nombre AS actividad_nombre FROM retos r INNER JOIN actividades a ON r.actividad_id = a.id WHERE r.id = ?");
+$stmt->bind_param("i", $reto_id);
+$stmt->execute();
+$reto = $stmt->get_result()->fetch_assoc();
+
+if (!$reto) {
+    echo "<div class='alert alert-danger'>Reto no encontrado.</div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
+?>
+<div class="d-flex align-items-center justify-content-between mb-3">
+  <div class="d-flex align-items-center">
+    <div class="reto-icon me-3"><?= htmlspecialchars($reto['icono'] ?? '🎯') ?></div>
+    <div>
+      <h3 class="mb-1"><?= htmlspecialchars($reto['nombre']) ?></h3>
+      <p class="text-muted mb-0">Actividad: <a href="retos.php?actividad_id=<?= $reto['actividad_id'] ?>"><?= htmlspecialchars($reto['actividad_nombre']) ?></a></p>
+    </div>
+  </div>
+  <a href="retos.php?actividad_id=<?= $reto['actividad_id'] ?>" class="btn btn-outline-secondary">Volver</a>
+</div>
+
+<div class="card">
+  <div class="card-body">
+    <h5 class="card-title">Descripción</h5>
+    <p class="card-text"><?= nl2br(htmlspecialchars($reto['descripcion'] ?? '')) ?: '<span class="text-muted">Sin descripción</span>' ?></p>
+
+    <?php if (!empty($reto['imagen'])): ?>
+      <div class="mt-4">
+        <h5>Imagen</h5>
+        <img src="<?= htmlspecialchars($reto['imagen']) ?>" alt="Imagen del reto" class="img-fluid rounded border">
+      </div>
+    <?php endif; ?>
+
+    <?php if ($video_embed || !empty($reto['video_url'])): ?>
+      <div class="mt-4">
+        <h5>Video</h5>
+        <?php if ($video_embed): ?>
+          <div class="ratio ratio-16x9">
+            <iframe src="<?= htmlspecialchars($video_embed) ?>" title="Video del reto" allowfullscreen></iframe>
+          </div>
+        <?php else: ?>
+          <a href="<?= htmlspecialchars($reto['video_url']) ?>" target="_blank" rel="noopener">Ver video</a>
+        <?php endif; ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if (!empty($reto['pdf'])): ?>
+      <div class="mt-4">
+        <h5>Documento PDF</h5>
+        <a href="<?= htmlspecialchars($reto['pdf']) ?>" class="btn btn-outline-secondary mb-3" target="_blank" rel="noopener">Abrir PDF</a>
+        <div class="ratio ratio-16x9">
+          <iframe src="<?= htmlspecialchars($reto['pdf']) ?>" title="PDF del reto"></iframe>
+        </div>
+      </div>
+    <?php endif; ?>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/retos.php
+++ b/retos.php
@@ -3,6 +3,58 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
+$iconosDisponibles = [
+  '🎯' => 'Objetivo',
+  '🚀' => 'Despegue',
+  '🧠' => 'Ingenio',
+  '⚙️' => 'Construcción',
+  '📚' => 'Aprendizaje',
+  '🌟' => 'Destacado',
+  '🧩' => 'Rompecabezas'
+];
+
+$columnaIcono = $conn->query("SHOW COLUMNS FROM retos LIKE 'icono'");
+if ($columnaIcono && $columnaIcono->num_rows === 0) {
+  $conn->query("ALTER TABLE retos ADD COLUMN icono VARCHAR(10) DEFAULT '🎯' AFTER pdf");
+}
+if ($columnaIcono instanceof mysqli_result) {
+  $columnaIcono->free();
+}
+
+function subirArchivo(string $campo, array $extensionesPermitidas): ?string {
+  if (!isset($_FILES[$campo]) || !is_array($_FILES[$campo])) {
+    return null;
+  }
+
+  $archivo = $_FILES[$campo];
+  $error = $archivo['error'] ?? UPLOAD_ERR_NO_FILE;
+  if ($error === UPLOAD_ERR_NO_FILE) {
+    return null;
+  }
+  if ($error !== UPLOAD_ERR_OK) {
+    return null;
+  }
+
+  $extension = strtolower(pathinfo($archivo['name'] ?? '', PATHINFO_EXTENSION));
+  if ($extension === '' || !in_array($extension, $extensionesPermitidas, true)) {
+    return null;
+  }
+
+  $rutaDirectorio = __DIR__.'/assets/uploads/retos';
+  if (!is_dir($rutaDirectorio)) {
+    mkdir($rutaDirectorio, 0775, true);
+  }
+
+  $nombreArchivo = uniqid('reto_', true).'.'.$extension;
+  $rutaDestino = $rutaDirectorio.'/'.$nombreArchivo;
+
+  if (!move_uploaded_file($archivo['tmp_name'] ?? '', $rutaDestino)) {
+    return null;
+  }
+
+  return 'assets/uploads/retos/'.$nombreArchivo;
+}
+
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;
 if ($actividad_id <= 0) { echo "<div class='alert alert-danger'>Actividad no valida.</div>"; include 'includes/footer.php'; exit; }
 
@@ -13,63 +65,184 @@ $stmt->execute();
 $actividad = $stmt->get_result()->fetch_assoc();
 if (!$actividad) { echo "<div class='alert alert-danger'>Actividad no encontrada.</div>"; include 'includes/footer.php'; exit; }
 
-// Agregar reto
-if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['nombre'])) {
+// Crear / editar reto
+if ($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['guardar_reto'])) {
   $nombre = trim($_POST['nombre']);
   $descripcion = trim($_POST['descripcion'] ?? '');
-  if ($nombre !== '') {
-    $stmt = $conn->prepare("INSERT INTO retos (actividad_id, nombre, descripcion) VALUES (?, ?, ?)");
-    $stmt->bind_param("iss", $actividad_id, $nombre, $descripcion);
-    $stmt->execute();
+  $video_url = trim($_POST['video_url'] ?? '');
+  $icono = $_POST['icono'] ?? '';
+  $reto_id = isset($_POST['reto_id']) ? (int)$_POST['reto_id'] : 0;
+
+  if (!array_key_exists($icono, $iconosDisponibles)) {
+    $claves = array_keys($iconosDisponibles);
+    $icono = $claves[0];
   }
+
+  $imagenSubida = subirArchivo('imagen', ['jpg', 'jpeg', 'png', 'gif']);
+  $pdfSubido = subirArchivo('pdf', ['pdf']);
+
+  if ($video_url !== '' && !preg_match('/^https?:\/\//i', $video_url)) {
+    $video_url = 'https://'.$video_url;
+  }
+  if ($video_url === '') {
+    $video_url = null;
+  }
+
+  if ($nombre !== '') {
+    if ($reto_id > 0) {
+      $stmt = $conn->prepare("SELECT imagen, pdf FROM retos WHERE id=? AND actividad_id=?");
+      $stmt->bind_param("ii", $reto_id, $actividad_id);
+      $stmt->execute();
+      $actual = $stmt->get_result()->fetch_assoc();
+      if (!$actual) {
+        header("Location: retos.php?actividad_id=".$actividad_id); exit;
+      }
+      $imagenActual = $actual['imagen'] ?? null;
+      $pdfActual = $actual['pdf'] ?? null;
+
+      if ($imagenSubida) {
+        if ($imagenActual && is_file(__DIR__.'/'.$imagenActual)) {
+          @unlink(__DIR__.'/'.$imagenActual);
+        }
+        $imagenActual = $imagenSubida;
+      }
+
+      if ($pdfSubido) {
+        if ($pdfActual && is_file(__DIR__.'/'.$pdfActual)) {
+          @unlink(__DIR__.'/'.$pdfActual);
+        }
+        $pdfActual = $pdfSubido;
+      }
+
+      $stmt = $conn->prepare("UPDATE retos SET nombre=?, descripcion=?, imagen=?, video_url=?, pdf=?, icono=? WHERE id=? AND actividad_id=?");
+      $stmt->bind_param("ssssssii", $nombre, $descripcion, $imagenActual, $video_url, $pdfActual, $icono, $reto_id, $actividad_id);
+      $stmt->execute();
+    } else {
+      $stmt = $conn->prepare("INSERT INTO retos (actividad_id, nombre, descripcion, imagen, video_url, pdf, icono) VALUES (?, ?, ?, ?, ?, ?, ?)");
+      $stmt->bind_param("issssss", $actividad_id, $nombre, $descripcion, $imagenSubida, $video_url, $pdfSubido, $icono);
+      $stmt->execute();
+    }
+  }
+
   header("Location: retos.php?actividad_id=".$actividad_id); exit;
 }
 
 // Eliminar reto
 if (isset($_GET['eliminar'])) {
   $id = (int)$_GET['eliminar'];
-  $conn->query("DELETE FROM retos WHERE id=$id AND actividad_id=$actividad_id");
+  $stmt = $conn->prepare("SELECT imagen, pdf FROM retos WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $id, $actividad_id);
+  $stmt->execute();
+  if ($registro = $stmt->get_result()->fetch_assoc()) {
+    foreach (['imagen', 'pdf'] as $campo) {
+      if (!empty($registro[$campo])) {
+        $ruta = __DIR__.'/'.$registro[$campo];
+        if (is_file($ruta)) {
+          unlink($ruta);
+        }
+      }
+    }
+  }
+
+  $stmt = $conn->prepare("DELETE FROM retos WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $id, $actividad_id);
+  $stmt->execute();
   header("Location: retos.php?actividad_id=".$actividad_id); exit;
 }
 
-$res = $conn->prepare("SELECT id, nombre, descripcion FROM retos WHERE actividad_id=? ORDER BY id DESC");
+$res = $conn->prepare("SELECT id, nombre, descripcion, imagen, video_url, pdf, icono FROM retos WHERE actividad_id=? ORDER BY id DESC");
 $res->bind_param("i", $actividad_id);
 $res->execute();
 $retos = $res->get_result();
+
+$retoEditar = null;
+if (isset($_GET['editar'])) {
+  $editar_id = (int)$_GET['editar'];
+  $stmt = $conn->prepare("SELECT id, nombre, descripcion, imagen, video_url, pdf, icono FROM retos WHERE id=? AND actividad_id=?");
+  $stmt->bind_param("ii", $editar_id, $actividad_id);
+  $stmt->execute();
+  $retoEditar = $stmt->get_result()->fetch_assoc();
+}
 ?>
 <div class="d-flex align-items-center justify-content-between mb-3">
   <h3>Retos - <?= htmlspecialchars($actividad['nombre']) ?></h3>
   <a href="actividades.php" class="btn btn-outline-secondary">Volver</a>
 </div>
 
-<form method="post" class="row g-3 mb-4">
+<form method="post" class="row g-3 mb-4" enctype="multipart/form-data">
+  <input type="hidden" name="guardar_reto" value="1">
+  <input type="hidden" name="reto_id" value="<?= $retoEditar['id'] ?? 0 ?>">
   <div class="col-md-4">
-    <input type="text" name="nombre" class="form-control" placeholder="Nombre del reto" required>
+    <input type="text" name="nombre" class="form-control" placeholder="Nombre del reto" value="<?= htmlspecialchars($retoEditar['nombre'] ?? '') ?>" required>
   </div>
-  <div class="col-md-6">
-    <input type="text" name="descripcion" class="form-control" placeholder="Descripción (opcional)">
+  <div class="col-md-4">
+    <input type="text" name="descripcion" class="form-control" placeholder="Descripción (opcional)" value="<?= htmlspecialchars($retoEditar['descripcion'] ?? '') ?>">
   </div>
-  <div class="col-md-2 d-grid">
-    <button class="btn btn-primary">Agregar reto</button>
+  <div class="col-md-4">
+    <input type="url" name="video_url" class="form-control" placeholder="URL de video de YouTube (opcional)" value="<?= htmlspecialchars($retoEditar['video_url'] ?? '') ?>">
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Icono del reto</label>
+    <select name="icono" class="form-select" required>
+      <?php foreach ($iconosDisponibles as $iconoValor => $iconoNombre): ?>
+        <option value="<?= htmlspecialchars($iconoValor) ?>" <?= (($retoEditar['icono'] ?? '') === $iconoValor) ? 'selected' : '' ?>><?= $iconoValor ?> - <?= htmlspecialchars($iconoNombre) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Imagen (opcional)</label>
+    <input type="file" name="imagen" class="form-control" accept="image/*">
+    <?php if (!empty($retoEditar['imagen'])): ?>
+      <div class="form-text">Se mantiene la imagen actual a menos que selecciones una nueva.</div>
+    <?php endif; ?>
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Archivo PDF (opcional)</label>
+    <input type="file" name="pdf" class="form-control" accept="application/pdf">
+    <?php if (!empty($retoEditar['pdf'])): ?>
+      <div class="form-text">Se mantiene el PDF actual a menos que cargues uno nuevo.</div>
+    <?php endif; ?>
+  </div>
+  <div class="col-md-4 d-grid align-content-end">
+    <button class="btn btn-primary"><?= $retoEditar ? 'Actualizar reto' : 'Agregar reto' ?></button>
   </div>
 </form>
 
-<div class="table-responsive">
-<table class="table table-striped align-middle">
-  <thead><tr><th>#</th><th>Nombre</th><th>Descripción</th><th>Acciones</th></tr></thead>
-  <tbody>
+<?php if ($retoEditar): ?>
+  <div class="alert alert-info">Editando el reto "<?= htmlspecialchars($retoEditar['nombre']) ?>". <a href="retos.php?actividad_id=<?= $actividad_id ?>">Cancelar edición</a></div>
+<?php endif; ?>
+
+<?php if ($retos->num_rows === 0): ?>
+  <div class="alert alert-secondary">Aún no hay retos registrados para esta actividad.</div>
+<?php else: ?>
+  <div class="row g-3">
     <?php while($r = $retos->fetch_assoc()): ?>
-      <tr>
-        <td><?= $r['id'] ?></td>
-        <td><?= htmlspecialchars($r['nombre']) ?></td>
-        <td><?= htmlspecialchars($r['descripcion']) ?></td>
-        <td>
-          <a class="btn btn-sm btn-danger" href="retos.php?actividad_id=<?= $actividad_id ?>&eliminar=<?= $r['id'] ?>" onclick="return confirm('¿Eliminar reto?');">Eliminar</a>
-        </td>
-      </tr>
+      <div class="col-md-6 col-lg-4">
+        <div class="card h-100 shadow-sm">
+          <div class="card-body d-flex flex-column">
+            <div class="d-flex align-items-center mb-3">
+              <div class="reto-icon me-3"><?= htmlspecialchars($r['icono'] ?? '🎯') ?></div>
+              <div>
+                <h5 class="card-title mb-0"><a href="reto_detalle.php?id=<?= $r['id'] ?>" class="text-decoration-none"><?= htmlspecialchars($r['nombre']) ?></a></h5>
+                <small class="text-muted">Reto #<?= $r['id'] ?></small>
+              </div>
+            </div>
+            <p class="card-text flex-grow-1"><?= $r['descripcion'] ? htmlspecialchars($r['descripcion']) : '<span class="text-muted">Sin descripción</span>' ?></p>
+            <div class="mb-3">
+              <?php if(!empty($r['imagen'])): ?><span class="badge bg-info me-1">Imagen</span><?php endif; ?>
+              <?php if(!empty($r['video_url'])): ?><span class="badge bg-danger me-1">Video</span><?php endif; ?>
+              <?php if(!empty($r['pdf'])): ?><span class="badge bg-secondary me-1">PDF</span><?php endif; ?>
+            </div>
+            <div class="mt-auto">
+              <a class="btn btn-sm btn-outline-primary me-2" href="reto_detalle.php?id=<?= $r['id'] ?>">Ver detalle</a>
+              <a class="btn btn-sm btn-outline-secondary me-2" href="retos.php?actividad_id=<?= $actividad_id ?>&editar=<?= $r['id'] ?>">Editar</a>
+              <a class="btn btn-sm btn-danger" href="retos.php?actividad_id=<?= $actividad_id ?>&eliminar=<?= $r['id'] ?>" onclick="return confirm('¿Eliminar reto?');">Eliminar</a>
+            </div>
+          </div>
+        </div>
+      </div>
     <?php endwhile; ?>
-  </tbody>
-</table>
-</div>
+  </div>
+<?php endif; ?>
 
 <?php include 'includes/footer.php'; ?>

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -50,6 +50,10 @@ CREATE TABLE IF NOT EXISTS retos (
   actividad_id INT NOT NULL,
   nombre VARCHAR(150) NOT NULL,
   descripcion TEXT,
+  imagen VARCHAR(255),
+  video_url VARCHAR(255),
+  pdf VARCHAR(255),
+  icono VARCHAR(10) DEFAULT '🎯',
   CONSTRAINT fk_reto_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 


### PR DESCRIPTION
## Summary
- permitir editar actividades con formularios prellenados y botones de edición
- habilitar la edición de estudiantes con actualización opcional de avatar
- transformar la gestión de retos a tarjetas con icono seleccionable, soporte de edición y esquema actualizado

## Testing
- php -l actividades.php
- php -l estudiantes.php
- php -l retos.php
- php -l reto_detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68d4bbf77c788326af87f5a509a55fc1