### PR TITLE
Agregar contenido ampliado para retos

### DIFF
--- a/reto_detalle.php
+++ b/reto_detalle.php
@@ -14,6 +14,18 @@ function obtenerEmbedYoutube(?string $url): ?string {
     return null;
 }
 
+function limpiarContenidoBlog(?string $html): string {
+    if ($html === null) {
+        return '';
+    }
+    $permitidos = '<p><a><strong><em><u><ol><ul><li><h1><h2><h3><h4><h5><h6><blockquote><img><figure><figcaption><table><thead><tbody><tr><th><td><span><br><hr><pre><code><div>';
+    $sanitizado = strip_tags($html, $permitidos);
+    $sanitizado = preg_replace('/on\w+\s*=\s*("|\').*?\1/i', '', $sanitizado);
+    $sanitizado = preg_replace('/(href|src)\s*=\s*"javascript:[^"]*"/i', '$1="#"', $sanitizado);
+    $sanitizado = preg_replace("/(href|src)\s*=\s*'javascript:[^']*'/i", "$1='#'", $sanitizado);
+    return $sanitizado;
+}
+
 $reto_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 if ($reto_id <= 0) {
     echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-flag'></i></div><h4 class='fw-semibold mb-2'>Reto no válido</h4><p class='text-muted mb-0'>Regresa al listado de <a href='actividades.php'>actividades</a> para seleccionar uno disponible.</p></div></div>";
@@ -21,7 +33,7 @@ if ($reto_id <= 0) {
     exit;
 }
 
-$stmt = $conn->prepare("SELECT r.id, r.nombre, r.descripcion, r.imagen, r.video_url, r.pdf, a.id AS actividad_id, a.nombre AS actividad_nombre FROM retos r INNER JOIN actividades a ON r.actividad_id = a.id WHERE r.id = ?");
+$stmt = $conn->prepare("SELECT r.id, r.nombre, r.descripcion, r.contenido_blog, r.imagen, r.video_url, r.pdf, a.id AS actividad_id, a.nombre AS actividad_nombre FROM retos r INNER JOIN actividades a ON r.actividad_id = a.id WHERE r.id = ?");
 $stmt->bind_param("i", $reto_id);
 $stmt->execute();
 $reto = $stmt->get_result()->fetch_assoc();
@@ -33,11 +45,12 @@ if (!$reto) {
 }
 
 $video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
+$contenido_blog = limpiarContenidoBlog($reto['contenido_blog'] ?? null);
 ?>
 <section class="page-header card border-0 shadow-sm mb-4">
   <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
     <div>
-      <h1 class="page-title mb-1"><i class="bi bi-flag-fill"></i> <?= htmlspecialchars($reto['nombre']) ?></h1>
+      <h1 class="page-title mb-1"><i class="bi bi-journal-richtext"></i> Detalle del reto</h1>
       <p class="page-subtitle mb-0">Actividad: <a href="retos.php?actividad_id=<?= $reto['actividad_id'] ?>" class="fw-semibold text-decoration-none"><?= htmlspecialchars($reto['actividad_nombre']) ?></a></p>
     </div>
     <div class="list-actions justify-content-lg-end">
@@ -47,35 +60,39 @@ $video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
   </div>
 </section>
 
-<div class="card section-card">
-  <div class="card-body">
-    <div class="d-flex flex-column flex-lg-row gap-4">
-      <div class="flex-grow-1">
-        <h5 class="fw-semibold mb-3">Descripción</h5>
-        <p class="text-muted mb-4"><?= nl2br(htmlspecialchars($reto['descripcion'] ?? '')) ?: '<span class="fst-italic">Sin descripción registrada</span>' ?></p>
-
-        <div class="d-flex flex-wrap gap-2 mb-4">
-          <?php if (!empty($reto['imagen'])): ?><span class="badge rounded-pill text-bg-primary-subtle"><i class="bi bi-image-fill me-1"></i>Imagen</span><?php endif; ?>
-          <?php if (!empty($reto['video_url'])): ?><span class="badge rounded-pill bg-danger-subtle text-danger"><i class="bi bi-camera-video-fill me-1"></i>Video</span><?php endif; ?>
-          <?php if (!empty($reto['pdf'])): ?><span class="badge rounded-pill bg-secondary-subtle text-secondary"><i class="bi bi-file-earmark-pdf-fill me-1"></i>PDF</span><?php endif; ?>
-        </div>
-
-        <?php if (!empty($reto['pdf'])): ?>
-          <a href="<?= htmlspecialchars($reto['pdf']) ?>" class="btn btn-outline-secondary btn-icon mb-4" target="_blank" rel="noopener"><i class="bi bi-box-arrow-up-right"></i> Abrir documento</a>
-        <?php endif; ?>
-      </div>
-      <?php if (!empty($reto['imagen'])): ?>
-        <div class="flex-shrink-0 w-100" style="max-width: 420px;">
-          <div class="ratio ratio-4x3 rounded overflow-hidden shadow-sm">
-            <img src="<?= htmlspecialchars($reto['imagen']) ?>" alt="Imagen del reto" class="w-100 h-100" style="object-fit: cover;">
-          </div>
-        </div>
-      <?php endif; ?>
+<article class="card border-0 shadow-sm overflow-hidden mb-4">
+  <?php if (!empty($reto['imagen'])): ?>
+    <div class="ratio ratio-21x9 bg-dark">
+      <img src="<?= htmlspecialchars($reto['imagen']) ?>" alt="Imagen destacada del reto" class="w-100 h-100" style="object-fit: cover;">
     </div>
+  <?php else: ?>
+    <div class="bg-gradient p-5 text-center text-white" style="background: linear-gradient(135deg, #6366f1, #22d3ee);">
+      <i class="bi bi-stars display-4"></i>
+    </div>
+  <?php endif; ?>
+  <div class="card-body p-4 p-lg-5">
+    <span class="badge text-bg-primary-soft text-uppercase mb-3">Reto académico</span>
+    <h1 class="display-6 fw-bold text-dark mb-3"><?= htmlspecialchars($reto['nombre']) ?></h1>
+    <p class="lead text-muted mb-4"><?= nl2br(htmlspecialchars($reto['descripcion'] ?? '')) ?: '<span class="fst-italic">Sin descripción registrada</span>' ?></p>
+    <div class="d-flex flex-wrap gap-2">
+      <?php if (!empty($reto['video_url'])): ?><span class="badge rounded-pill bg-danger-subtle text-danger"><i class="bi bi-camera-video-fill me-1"></i>Video de referencia</span><?php endif; ?>
+      <?php if (!empty($reto['pdf'])): ?><span class="badge rounded-pill bg-secondary-subtle text-secondary"><i class="bi bi-file-earmark-pdf-fill me-1"></i>Documento PDF</span><?php endif; ?>
+      <?php if ($contenido_blog !== ''): ?><span class="badge rounded-pill bg-success-subtle text-success"><i class="bi bi-journal-text me-1"></i>Contenido ampliado</span><?php endif; ?>
+    </div>
+  </div>
+</article>
+
+<div class="card section-card">
+  <div class="card-body p-4 p-lg-5">
+    <?php if ($contenido_blog !== ''): ?>
+      <div class="blog-content mb-5">
+        <?= $contenido_blog ?>
+      </div>
+    <?php endif; ?>
 
     <?php if ($video_embed || !empty($reto['video_url'])): ?>
-      <div class="mt-4">
-        <h5 class="fw-semibold mb-3">Video</h5>
+      <section class="mb-5">
+        <h2 class="h4 fw-semibold mb-3"><i class="bi bi-camera-video"></i> Video de referencia</h2>
         <?php if ($video_embed): ?>
           <div class="ratio ratio-16x9 rounded overflow-hidden shadow-sm">
             <iframe src="<?= htmlspecialchars($video_embed) ?>" title="Video del reto" allowfullscreen></iframe>
@@ -83,18 +100,59 @@ $video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
         <?php else: ?>
           <a href="<?= htmlspecialchars($reto['video_url']) ?>" target="_blank" rel="noopener" class="btn btn-outline-primary btn-icon"><i class="bi bi-play-circle"></i> Ver video</a>
         <?php endif; ?>
-      </div>
+      </section>
     <?php endif; ?>
 
     <?php if (!empty($reto['pdf'])): ?>
-      <div class="mt-4">
-        <h5 class="fw-semibold mb-3">Documento PDF</h5>
-        <div class="ratio ratio-16x9 rounded overflow-hidden shadow-sm">
+      <section class="mb-4">
+        <h2 class="h4 fw-semibold mb-3"><i class="bi bi-file-earmark-pdf"></i> Documento descargable</h2>
+        <div class="ratio ratio-16x9 rounded overflow-hidden shadow-sm mb-3">
           <iframe src="<?= htmlspecialchars($reto['pdf']) ?>" title="PDF del reto"></iframe>
         </div>
-      </div>
+        <a href="<?= htmlspecialchars($reto['pdf']) ?>" class="btn btn-outline-secondary btn-icon" target="_blank" rel="noopener"><i class="bi bi-download"></i> Descargar PDF</a>
+      </section>
     <?php endif; ?>
   </div>
 </div>
+
+<style>
+  .badge.text-bg-primary-soft {
+    background-color: rgba(99, 102, 241, 0.12);
+    color: #3730a3;
+  }
+  .blog-content p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: #495057;
+  }
+  .blog-content h2,
+  .blog-content h3,
+  .blog-content h4 {
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+    font-weight: 600;
+    color: #212529;
+  }
+  .blog-content img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 0.75rem;
+    margin: 1.5rem 0;
+    box-shadow: 0 0.5rem 1.5rem rgba(15, 23, 42, 0.15);
+  }
+  .blog-content ul,
+  .blog-content ol {
+    padding-left: 1.25rem;
+    margin-bottom: 1.25rem;
+  }
+  .blog-content blockquote {
+    border-left: 4px solid rgba(99, 102, 241, 0.4);
+    padding-left: 1rem;
+    color: #4c51bf;
+    font-style: italic;
+    background-color: rgba(99, 102, 241, 0.08);
+    border-radius: 0.5rem;
+  }
+</style>
 
 <?php include 'includes/footer.php'; ?>

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS retos (
   actividad_id INT NOT NULL,
   nombre VARCHAR(150) NOT NULL,
   descripcion TEXT,
+  contenido_blog LONGTEXT,
   imagen VARCHAR(255),
   video_url VARCHAR(255),
   pdf VARCHAR(255),


### PR DESCRIPTION
## Summary
- permitir guardar contenido extendido para cada reto, incluyendo texto enriquecido
- integrar TinyMCE en el formulario de retos y ampliar el esquema para almacenar el contenido
- rediseñar la vista de detalle del reto con estilo de blog y mostrar todos los recursos disponibles

## Testing
- php -l retos.php
- php -l reto_detalle.php

------
https://chatgpt.com/codex/tasks/task_e_68d54c2e3a28832682c026ab5c2b27bd