### PR TITLE
Ajustar control de inserción en retroalimentación de retos

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -199,6 +199,75 @@
   object-fit: cover;
 }
 
+.credential-box {
+  background: rgba(48, 88, 214, 0.08);
+  border: 1px dashed rgba(48, 88, 214, 0.4);
+}
+
+.credential-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: #fff;
+  border-radius: 999px;
+  padding: 0.35rem 0.85rem;
+  box-shadow: 0 6px 14px rgba(48, 88, 214, 0.1);
+  font-size: 0.95rem;
+}
+
+.reto-list-item {
+  transition: all 0.2s ease-in-out;
+}
+
+.reto-list-item:hover {
+  background: rgba(48, 88, 214, 0.06);
+  transform: translateY(-2px);
+}
+
+.timeline-feedback {
+  position: relative;
+  padding-left: 1.5rem;
+}
+
+.timeline-feedback::before {
+  content: '';
+  position: absolute;
+  top: 0.4rem;
+  bottom: 0.4rem;
+  left: 0.5rem;
+  width: 2px;
+  background: rgba(48, 88, 214, 0.2);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 1.5rem;
+  padding-left: 0.5rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1rem;
+  top: 0.35rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #22c55e;
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.timeline-dot.bg-primary {
+  background: #3058d6;
+  box-shadow: 0 0 0 4px rgba(48, 88, 214, 0.15);
+}
+
+.timeline-content {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
 .list-actions {
   display: flex;
   gap: 0.5rem;

--- a/assets/retroalimentaciones/.gitignore
+++ b/assets/retroalimentaciones/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/estudiantes.php
+++ b/estudiantes.php
@@ -3,119 +3,197 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
+$mensajeCredenciales = $_SESSION['credenciales_generadas'] ?? null;
+unset($_SESSION['credenciales_generadas']);
+
+function normalizarUsuario(string $texto): string {
+    $usuario = strtolower(trim($texto));
+    $usuario = preg_replace('/[^a-z0-9]/', '', $usuario);
+    if ($usuario === '') {
+        $usuario = 'estudiante';
+    }
+    return substr($usuario, 0, 30);
+}
+
+function generarClaveAcceso(int $longitud = 8): string {
+    $caracteres = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789';
+    $clave = '';
+    for ($i = 0; $i < $longitud; $i++) {
+        $clave .= $caracteres[random_int(0, strlen($caracteres) - 1)];
+    }
+    return $clave;
+}
+
+function generarUsuarioUnico(mysqli $conn, string $textoBase, ?int $excluirId = null): string {
+    $base = normalizarUsuario($textoBase);
+    $usuario = $base;
+    $contador = 1;
+
+    while (true) {
+        if ($excluirId) {
+            $stmt = $conn->prepare('SELECT id FROM estudiantes WHERE usuario = ? AND id <> ? LIMIT 1');
+            $stmt->bind_param('si', $usuario, $excluirId);
+        } else {
+            $stmt = $conn->prepare('SELECT id FROM estudiantes WHERE usuario = ? LIMIT 1');
+            $stmt->bind_param('s', $usuario);
+        }
+        $stmt->execute();
+        $existe = $stmt->get_result()->fetch_assoc();
+        if (!$existe) {
+            return $usuario;
+        }
+        $usuario = substr($base, 0, 25) . $contador;
+        $contador++;
+    }
+}
+
 $actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;
-if ($actividad_id<=0) {
-  echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-exclamation-octagon'></i></div><h4 class='fw-semibold mb-2'>Actividad no válida</h4><p class='text-muted mb-0'>Vuelve a <a href='actividades.php'>Actividades</a> y selecciona una opción disponible.</p></div></div>";
-  include 'includes/footer.php';
-  exit;
+if ($actividad_id <= 0) {
+    echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-exclamation-octagon'></i></div><h4 class='fw-semibold mb-2'>Actividad no válida</h4><p class='text-muted mb-0'>Vuelve a <a href='actividades.php'>Actividades</a> y selecciona una opción disponible.</p></div></div>";
+    include 'includes/footer.php';
+    exit;
 }
 
-// Actividad
-$stmt=$conn->prepare("SELECT id, nombre FROM actividades WHERE id=?");
-$stmt->bind_param("i",$actividad_id);
+$stmt = $conn->prepare('SELECT id, nombre FROM actividades WHERE id = ?');
+$stmt->bind_param('i', $actividad_id);
 $stmt->execute();
-$actividad=$stmt->get_result()->fetch_assoc();
-if(!$actividad){
-  echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-search'></i></div><h4 class='fw-semibold mb-2'>Actividad no encontrada</h4><p class='text-muted mb-0'>Puede que haya sido eliminada. Revisa el listado de actividades disponibles.</p></div></div>";
-  include 'includes/footer.php';
-  exit;
+$actividad = $stmt->get_result()->fetch_assoc();
+if (!$actividad) {
+    echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-search'></i></div><h4 class='fw-semibold mb-2'>Actividad no encontrada</h4><p class='text-muted mb-0'>Puede que haya sido eliminada. Revisa el listado de actividades disponibles.</p></div></div>";
+    include 'includes/footer.php';
+    exit;
 }
 
-// Agregar/editar estudiante
 $estudianteEdit = null;
 if (isset($_GET['editar'])) {
-  $editarId = (int)$_GET['editar'];
-  $stmt = $conn->prepare("SELECT id, nombre, avatar FROM estudiantes WHERE id=? AND actividad_id=?");
-  $stmt->bind_param("ii", $editarId, $actividad_id);
-  $stmt->execute();
-  $estudianteEdit = $stmt->get_result()->fetch_assoc();
+    $editarId = (int)$_GET['editar'];
+    $stmt = $conn->prepare('SELECT id, nombre, avatar, usuario, clave_acceso FROM estudiantes WHERE id = ? AND actividad_id = ?');
+    $stmt->bind_param('ii', $editarId, $actividad_id);
+    $stmt->execute();
+    $estudianteEdit = $stmt->get_result()->fetch_assoc();
 }
 
-if($_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['nombre']) && empty($_POST['estudiante_id'])){
-  $nombre = trim($_POST['nombre']);
-  $avatar = 'default.png';
-  if(!empty($_FILES['avatar']['name'])){
-    $ext = strtolower(pathinfo($_FILES['avatar']['name'], PATHINFO_EXTENSION));
-    if (!in_array($ext, ['jpg','jpeg','png','gif','webp'])) { $ext = 'png'; }
-    $fname = 'avatar_' . time() . '_' . rand(1000,9999) . '.' . $ext;
-    $dest = 'assets/img/avatars/' . $fname;
-    if (is_uploaded_file($_FILES['avatar']['tmp_name'])) {
-      @move_uploaded_file($_FILES['avatar']['tmp_name'], $dest);
-      if (file_exists($dest)) { $avatar = $fname; }
-    }
-  }
-  if($nombre!==''){
-    $stmt = $conn->prepare("INSERT INTO estudiantes (nombre, avatar, actividad_id) VALUES (?, ?, ?)");
-    $stmt->bind_param("ssi", $nombre, $avatar, $actividad_id);
-    $stmt->execute();
-  }
-  header("Location: estudiantes.php?actividad_id=".$actividad_id); exit;
-}
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['nombre']) && empty($_POST['estudiante_id'])) {
+    $nombre = trim($_POST['nombre']);
+    $usuarioIngresado = trim($_POST['usuario'] ?? '');
+    $claveIngresada = trim($_POST['clave_acceso'] ?? '');
+    $avatar = 'default.png';
 
-if($_SERVER['REQUEST_METHOD']==='POST' && !empty($_POST['estudiante_id'])){
-  $estudianteId = (int)$_POST['estudiante_id'];
-  $nombre = trim($_POST['nombre']);
-  if($nombre!==''){
-    $stmt = $conn->prepare("SELECT avatar FROM estudiantes WHERE id=? AND actividad_id=?");
-    $stmt->bind_param("ii", $estudianteId, $actividad_id);
-    $stmt->execute();
-    if ($actual = $stmt->get_result()->fetch_assoc()) {
-      $avatar = $actual['avatar'];
-      if(!empty($_FILES['avatar']['name'])){
+    if (!empty($_FILES['avatar']['name'])) {
         $ext = strtolower(pathinfo($_FILES['avatar']['name'], PATHINFO_EXTENSION));
         if (!in_array($ext, ['jpg','jpeg','png','gif','webp'])) { $ext = 'png'; }
         $fname = 'avatar_' . time() . '_' . rand(1000,9999) . '.' . $ext;
         $dest = 'assets/img/avatars/' . $fname;
         if (is_uploaded_file($_FILES['avatar']['tmp_name'])) {
-          @move_uploaded_file($_FILES['avatar']['tmp_name'], $dest);
-          if (file_exists($dest)) {
-            if ($avatar && $avatar!=='default.png' && file_exists('assets/img/avatars/'.$avatar)) {
-              @unlink('assets/img/avatars/'.$avatar);
-            }
-            $avatar = $fname;
-          }
+            @move_uploaded_file($_FILES['avatar']['tmp_name'], $dest);
+            if (file_exists($dest)) { $avatar = $fname; }
         }
-      }
-
-      $stmt = $conn->prepare("UPDATE estudiantes SET nombre=?, avatar=? WHERE id=? AND actividad_id=?");
-      $stmt->bind_param("ssii", $nombre, $avatar, $estudianteId, $actividad_id);
-      $stmt->execute();
     }
-  }
-  header("Location: estudiantes.php?actividad_id=".$actividad_id); exit;
+
+    if ($nombre !== '') {
+        $usuarioFinal = generarUsuarioUnico($conn, $usuarioIngresado !== '' ? $usuarioIngresado : $nombre);
+        $claveFinal = $claveIngresada !== '' ? $claveIngresada : generarClaveAcceso();
+        $hash = password_hash($claveFinal, PASSWORD_DEFAULT);
+
+        $stmt = $conn->prepare('INSERT INTO estudiantes (nombre, avatar, actividad_id, usuario, clave_acceso, password_hash) VALUES (?, ?, ?, ?, ?, ?)');
+        $stmt->bind_param('ssisss', $nombre, $avatar, $actividad_id, $usuarioFinal, $claveFinal, $hash);
+        $stmt->execute();
+
+        $_SESSION['credenciales_generadas'] = [
+            'tipo' => 'creado',
+            'nombre' => $nombre,
+            'usuario' => $usuarioFinal,
+            'clave' => $claveFinal
+        ];
+    }
+
+    header('Location: estudiantes.php?actividad_id='.$actividad_id);
+    exit;
 }
 
-// Eliminar
-if(isset($_GET['eliminar'])){
-  $id=(int)$_GET['eliminar'];
-  $resAv = $conn->query("SELECT avatar FROM estudiantes WHERE id=$id AND actividad_id=$actividad_id");
-  if ($resAv && $row=$resAv->fetch_assoc()) {
-    if ($row['avatar'] && $row['avatar']!=='default.png') {
-      $path='assets/img/avatars/'.$row['avatar'];
-      if (file_exists($path)) { @unlink($path); }
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['estudiante_id'])) {
+    $estudianteId = (int)$_POST['estudiante_id'];
+    $nombre = trim($_POST['nombre']);
+    $usuarioIngresado = trim($_POST['usuario'] ?? '');
+    $claveIngresada = trim($_POST['clave_acceso'] ?? '');
+
+    if ($nombre !== '') {
+        $stmt = $conn->prepare('SELECT avatar, usuario, clave_acceso, password_hash FROM estudiantes WHERE id = ? AND actividad_id = ?');
+        $stmt->bind_param('ii', $estudianteId, $actividad_id);
+        $stmt->execute();
+        if ($actual = $stmt->get_result()->fetch_assoc()) {
+            $avatar = $actual['avatar'];
+
+            if (!empty($_FILES['avatar']['name'])) {
+                $ext = strtolower(pathinfo($_FILES['avatar']['name'], PATHINFO_EXTENSION));
+                if (!in_array($ext, ['jpg','jpeg','png','gif','webp'])) { $ext = 'png'; }
+                $fname = 'avatar_' . time() . '_' . rand(1000,9999) . '.' . $ext;
+                $dest = 'assets/img/avatars/' . $fname;
+                if (is_uploaded_file($_FILES['avatar']['tmp_name'])) {
+                    @move_uploaded_file($_FILES['avatar']['tmp_name'], $dest);
+                    if (file_exists($dest)) {
+                        if ($avatar && $avatar !== 'default.png' && file_exists('assets/img/avatars/'.$avatar)) {
+                            @unlink('assets/img/avatars/'.$avatar);
+                        }
+                        $avatar = $fname;
+                    }
+                }
+            }
+
+            $usuarioFinal = generarUsuarioUnico($conn, $usuarioIngresado !== '' ? $usuarioIngresado : $actual['usuario'], $estudianteId);
+            $claveFinal = $claveIngresada !== '' ? $claveIngresada : $actual['clave_acceso'];
+            $hash = ($claveIngresada !== '') ? password_hash($claveFinal, PASSWORD_DEFAULT) : ($actual['password_hash'] ?: password_hash($claveFinal, PASSWORD_DEFAULT));
+
+            $stmt = $conn->prepare('UPDATE estudiantes SET nombre = ?, avatar = ?, usuario = ?, clave_acceso = ?, password_hash = ? WHERE id = ? AND actividad_id = ?');
+            $stmt->bind_param('ssssssi', $nombre, $avatar, $usuarioFinal, $claveFinal, $hash, $estudianteId, $actividad_id);
+            $stmt->execute();
+
+            $_SESSION['credenciales_generadas'] = [
+                'tipo' => 'actualizado',
+                'nombre' => $nombre,
+                'usuario' => $usuarioFinal,
+                'clave' => $claveFinal
+            ];
+        }
     }
-  }
-  $conn->query("DELETE FROM estudiantes WHERE id=$id AND actividad_id=$actividad_id");
-  header("Location: estudiantes.php?actividad_id=".$actividad_id); exit;
+
+    header('Location: estudiantes.php?actividad_id='.$actividad_id);
+    exit;
 }
 
-// Listado
-$q = "SELECT e.id, e.nombre, e.avatar, COALESCE(SUM(p.puntaje),0) AS total "
+if (isset($_GET['eliminar'])) {
+    $id = (int)$_GET['eliminar'];
+    $resAv = $conn->query('SELECT avatar FROM estudiantes WHERE id='.$id.' AND actividad_id='.$actividad_id);
+    if ($resAv && $row = $resAv->fetch_assoc()) {
+        if ($row['avatar'] && $row['avatar'] !== 'default.png') {
+            $path = 'assets/img/avatars/'.$row['avatar'];
+            if (file_exists($path)) { @unlink($path); }
+        }
+    }
+    $conn->query('DELETE FROM estudiantes WHERE id='.$id.' AND actividad_id='.$actividad_id);
+    header('Location: estudiantes.php?actividad_id='.$actividad_id);
+    exit;
+}
+
+$q = "SELECT e.id, e.nombre, e.avatar, e.usuario, e.clave_acceso, COALESCE(SUM(p.puntaje),0) AS total "
    . "FROM estudiantes e "
-   . "LEFT JOIN puntuaciones p ON p.estudiante_id=e.id "
-   . "WHERE e.actividad_id=? "
-   . "GROUP BY e.id, e.nombre, e.avatar "
+   . "LEFT JOIN puntuaciones p ON p.estudiante_id = e.id "
+   . "WHERE e.actividad_id = ? "
+   . "GROUP BY e.id, e.nombre, e.avatar, e.usuario, e.clave_acceso "
    . "ORDER BY e.id DESC";
-$stmt=$conn->prepare($q);
-$stmt->bind_param("i",$actividad_id);
+$stmt = $conn->prepare($q);
+$stmt->bind_param('i', $actividad_id);
 $stmt->execute();
-$estudiantes=$stmt->get_result();
+$estudiantes = $stmt->get_result();
+
+$usuarioPorDefecto = $estudianteEdit['usuario'] ?? ($_POST['usuario'] ?? generarUsuarioUnico($conn, $actividad['nombre'] ?? 'estudiante'));
+$clavePorDefecto = $estudianteEdit['clave_acceso'] ?? ($_POST['clave_acceso'] ?? generarClaveAcceso());
 ?>
 <section class="page-header card border-0 shadow-sm mb-4">
   <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
     <div>
       <h1 class="page-title mb-1"><i class="bi bi-people-fill"></i> Estudiantes</h1>
-      <p class="page-subtitle mb-0">Actividad: <span class="fw-semibold text-dark"><?= htmlspecialchars($actividad['nombre']) ?></span>. Gestiona participantes y sus avatares.</p>
+      <p class="page-subtitle mb-0">Actividad: <span class="fw-semibold text-dark"><?= htmlspecialchars($actividad['nombre']) ?></span>. Gestiona participantes, accesos y sus avatares.</p>
     </div>
     <div class="list-actions justify-content-lg-end">
       <a href="actividades.php" class="btn btn-outline-primary btn-icon"><i class="bi bi-arrow-left"></i> Volver a actividades</a>
@@ -128,6 +206,21 @@ $estudiantes=$stmt->get_result();
   <div class="alert alert-info shadow-sm">Editando estudiante <strong><?= htmlspecialchars($estudianteEdit['nombre']) ?></strong>. <a href="estudiantes.php?actividad_id=<?= $actividad_id ?>" class="alert-link">Cancelar</a></div>
 <?php endif; ?>
 
+<?php if ($mensajeCredenciales): ?>
+  <div class="alert alert-success shadow-sm">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+      <div>
+        <h5 class="fw-semibold mb-1"><i class="bi bi-key-fill me-2"></i>Credenciales <?= $mensajeCredenciales['tipo'] === 'creado' ? 'generadas' : 'actualizadas' ?> correctamente</h5>
+        <p class="mb-0">Comparte estos datos con <strong><?= htmlspecialchars($mensajeCredenciales['nombre']) ?></strong> para que pueda iniciar sesión como estudiante.</p>
+      </div>
+      <div class="d-flex flex-column flex-sm-row gap-2">
+        <span class="credential-chip"><strong>Usuario:</strong> <?= htmlspecialchars($mensajeCredenciales['usuario']) ?></span>
+        <span class="credential-chip"><strong>Clave:</strong> <?= htmlspecialchars($mensajeCredenciales['clave']) ?></span>
+      </div>
+    </div>
+  </div>
+<?php endif; ?>
+
 <form method="post" enctype="multipart/form-data" class="card section-card mb-4">
   <input type="hidden" name="estudiante_id" value="<?= $estudianteEdit['id'] ?? '' ?>">
   <div class="card-body">
@@ -136,12 +229,12 @@ $estudiantes=$stmt->get_result();
         <label for="nombre" class="form-label fw-semibold">Nombre del estudiante</label>
         <div class="input-group input-group-lg">
           <span class="input-group-text"><i class="bi bi-person"></i></span>
-          <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Ej. Sofía González" value="<?= htmlspecialchars($estudianteEdit['nombre'] ?? '') ?>" required>
+          <input type="text" id="nombre" name="nombre" class="form-control" placeholder="Ej. Sofía González" value="<?= htmlspecialchars($estudianteEdit['nombre'] ?? ($_POST['nombre'] ?? '')) ?>" required>
         </div>
       </div>
       <div class="col-md-5">
         <label for="avatar" class="form-label fw-semibold">Avatar (opcional)</label>
-        <?php if ($estudianteEdit && $estudianteEdit['avatar'] && $estudianteEdit['avatar']!=='default.png'): ?>
+        <?php if ($estudianteEdit && $estudianteEdit['avatar'] && $estudianteEdit['avatar'] !== 'default.png'): ?>
           <div class="form-text mb-2">Sube una imagen para reemplazar el avatar actual.</div>
         <?php endif; ?>
         <input type="file" id="avatar" name="avatar" class="form-control" accept="image/*">
@@ -151,6 +244,35 @@ $estudiantes=$stmt->get_result();
           <i class="bi <?= $estudianteEdit ? 'bi-arrow-repeat' : 'bi-person-plus' ?>"></i>
           <?= $estudianteEdit ? 'Actualizar' : 'Agregar' ?>
         </button>
+      </div>
+    </div>
+    <div class="row g-4 align-items-center mt-1">
+      <div class="col-md-4">
+        <label for="usuario" class="form-label fw-semibold">Usuario de acceso</label>
+        <div class="input-group input-group-lg">
+          <span class="input-group-text"><i class="bi bi-at"></i></span>
+          <input type="text" id="usuario" name="usuario" class="form-control" value="<?= htmlspecialchars($usuarioPorDefecto) ?>" required>
+        </div>
+        <div class="form-text">Puedes personalizarlo; se garantiza que no se repita.</div>
+      </div>
+      <div class="col-md-4">
+        <label for="clave_acceso" class="form-label fw-semibold">Clave de acceso</label>
+        <div class="input-group input-group-lg">
+          <span class="input-group-text"><i class="bi bi-key"></i></span>
+          <input type="text" id="clave_acceso" name="clave_acceso" class="form-control" value="<?= htmlspecialchars($clavePorDefecto) ?>" <?= $estudianteEdit ? '' : 'required' ?>>
+        </div>
+        <div class="form-text">Entrega esta clave al estudiante. Puedes cambiarla cuando lo necesites.</div>
+      </div>
+      <div class="col-md-4">
+        <div class="alert alert-secondary mb-0">
+          <div class="d-flex gap-2">
+            <i class="bi bi-info-circle-fill fs-4 text-primary"></i>
+            <div>
+              <strong>Zona estudiantes</strong>
+              <p class="mb-0">Pueden ingresar en <a href="login_estudiante.php" class="alert-link">login_estudiante.php</a> para revisar retos y enviar evidencias.</p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -163,17 +285,24 @@ $estudiantes=$stmt->get_result();
         <tr>
           <th class="text-uppercase">Avatar</th>
           <th class="text-uppercase">Nombre</th>
+          <th class="text-uppercase">Acceso</th>
           <th class="text-uppercase">Puntos</th>
           <th class="text-end text-uppercase">Acciones</th>
         </tr>
       </thead>
       <tbody>
-        <?php while($e=$estudiantes->fetch_assoc()): ?>
+        <?php while ($e = $estudiantes->fetch_assoc()): ?>
           <tr>
             <td>
               <img src="assets/img/avatars/<?= htmlspecialchars($e['avatar']) ?>" class="avatar-xl" alt="avatar de <?= htmlspecialchars($e['nombre']) ?>">
             </td>
             <td class="fw-semibold text-dark"><?= htmlspecialchars($e['nombre']) ?></td>
+            <td>
+              <div class="d-flex flex-column gap-1 small">
+                <span class="credential-chip"><i class="bi bi-person-badge"></i> <?= htmlspecialchars($e['usuario']) ?></span>
+                <span class="credential-chip"><i class="bi bi-key"></i> <?= htmlspecialchars($e['clave_acceso']) ?></span>
+              </div>
+            </td>
             <td><span class="badge bg-success fs-6"><i class="bi bi-stars me-1"></i><?= $e['total'] ?></span></td>
             <td class="text-end">
               <div class="btn-group" role="group">

--- a/includes/header_estudiante.php
+++ b/includes/header_estudiante.php
@@ -1,0 +1,55 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+$estudiante_actual = $_SESSION['estudiante_nombre'] ?? null;
+?>
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tablero del Guardián - Estudiante</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="assets/css/style.css" rel="stylesheet">
+</head>
+<body class="app-body">
+<nav class="navbar navbar-expand-lg app-navbar shadow-sm">
+  <div class="container-fluid px-3 px-lg-4">
+    <a class="navbar-brand d-flex align-items-center" href="perfil_estudiante.php">
+      <span class="brand-icon d-inline-flex align-items-center justify-content-center me-2">
+        <i class="bi bi-person-badge-fill"></i>
+      </span>
+      <span class="fw-semibold">Zona Estudiantes</span>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarEstudiante" aria-label="Alternar navegación">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarEstudiante">
+      <ul class="navbar-nav me-auto">
+        <?php if ($estudiante_actual): ?>
+          <li class="nav-item"><a class="nav-link" href="perfil_estudiante.php"><i class="bi bi-kanban me-1"></i>Mis actividades</a></li>
+        <?php endif; ?>
+      </ul>
+      <ul class="navbar-nav ms-auto align-items-lg-center">
+        <?php if ($estudiante_actual): ?>
+          <li class="nav-item">
+            <span class="navbar-text d-flex align-items-center me-lg-3">
+              <span class="user-avatar d-inline-flex align-items-center justify-content-center me-2"><i class="bi bi-person-circle"></i></span>
+              <span class="fw-medium">Hola, <?= htmlspecialchars($estudiante_actual) ?></span>
+            </span>
+          </li>
+          <li class="nav-item">
+            <a class="btn btn-sm btn-outline-light rounded-pill px-3" href="logout_estudiante.php"><i class="bi bi-box-arrow-right me-1"></i>Salir</a>
+          </li>
+        <?php else: ?>
+          <li class="nav-item"><a class="nav-link" href="login_estudiante.php"><i class="bi bi-box-arrow-in-right me-1"></i>Iniciar sesión</a></li>
+        <?php endif; ?>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">

--- a/includes/protect_estudiante.php
+++ b/includes/protect_estudiante.php
@@ -1,0 +1,9 @@
+<?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (empty($_SESSION['estudiante_id'])) {
+    header('Location: login_estudiante.php');
+    exit;
+}

--- a/index.php
+++ b/index.php
@@ -2,8 +2,14 @@
 session_start();
 
 if (isset($_SESSION['user_id'])) {
-    header("Location: actividades.php");
-} else {
-    header("Location: login.php");
+    header('Location: actividades.php');
+    exit;
 }
+
+if (isset($_SESSION['estudiante_id'])) {
+    header('Location: perfil_estudiante.php');
+    exit;
+}
+
+header('Location: login.php');
 exit;

--- a/login_estudiante.php
+++ b/login_estudiante.php
@@ -1,0 +1,108 @@
+<?php
+require_once 'includes/db.php';
+
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!empty($_SESSION['estudiante_id'])) {
+    header('Location: perfil_estudiante.php');
+    exit;
+}
+
+$errores = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $usuario = trim($_POST['usuario'] ?? '');
+    $clave = $_POST['clave'] ?? '';
+
+    if ($usuario === '' || $clave === '') {
+        $errores[] = 'Ingresa tu usuario y clave de acceso.';
+    } else {
+        $stmt = $conn->prepare('SELECT id, nombre, actividad_id, clave_acceso, password_hash FROM estudiantes WHERE usuario = ? LIMIT 1');
+        $stmt->bind_param('s', $usuario);
+        $stmt->execute();
+        $resultado = $stmt->get_result();
+        $estudiante = $resultado->fetch_assoc();
+
+        if ($estudiante) {
+            $hash = $estudiante['password_hash'] ?? '';
+            $clavePlano = $estudiante['clave_acceso'] ?? '';
+            $credencialValida = false;
+
+            if ($hash) {
+                $credencialValida = password_verify($clave, $hash);
+            }
+
+            if (!$credencialValida && $clavePlano !== '') {
+                // Compatibilidad con cuentas antiguas sin hash
+                $credencialValida = hash_equals($clavePlano, $clave);
+            }
+
+            if ($credencialValida) {
+                $_SESSION['estudiante_id'] = $estudiante['id'];
+                $_SESSION['estudiante_nombre'] = $estudiante['nombre'];
+                $_SESSION['estudiante_actividad_id'] = $estudiante['actividad_id'];
+                header('Location: perfil_estudiante.php');
+                exit;
+            }
+        }
+
+        $errores[] = 'Credenciales incorrectas. Verifica tus datos con tu docente.';
+    }
+}
+
+include 'includes/header_estudiante.php';
+?>
+
+<div class="row justify-content-center">
+  <div class="col-md-7 col-lg-5">
+    <div class="auth-card card border-0 shadow-sm">
+      <div class="card-body p-4 p-lg-5">
+        <div class="text-center mb-4">
+          <div class="auth-icon mb-3 mx-auto">
+            <i class="bi bi-person-lines-fill"></i>
+          </div>
+          <h2 class="fw-semibold mb-1">Acceso de estudiantes</h2>
+          <p class="text-muted mb-0">Utiliza los datos entregados por tu docente.</p>
+        </div>
+
+        <?php if ($errores): ?>
+          <div class="alert alert-danger">
+            <ul class="mb-0">
+              <?php foreach ($errores as $error): ?>
+                <li><?= htmlspecialchars($error) ?></li>
+              <?php endforeach; ?>
+            </ul>
+          </div>
+        <?php endif; ?>
+
+        <form method="post" class="mt-4">
+          <div class="mb-3">
+            <label for="usuario" class="form-label">Usuario</label>
+            <div class="input-group input-group-lg">
+              <span class="input-group-text"><i class="bi bi-person-fill"></i></span>
+              <input type="text" class="form-control" id="usuario" name="usuario" required value="<?= htmlspecialchars($_POST['usuario'] ?? '') ?>">
+            </div>
+          </div>
+          <div class="mb-3">
+            <label for="clave" class="form-label">Clave de acceso</label>
+            <div class="input-group input-group-lg">
+              <span class="input-group-text"><i class="bi bi-key-fill"></i></span>
+              <input type="password" class="form-control" id="clave" name="clave" required>
+            </div>
+          </div>
+          <div class="d-grid">
+            <button type="submit" class="btn btn-primary btn-lg"><i class="bi bi-box-arrow-in-right me-1"></i> Entrar</button>
+          </div>
+        </form>
+
+        <div class="text-center mt-4">
+          <span class="text-muted">¿Docente?</span> <a class="fw-semibold" href="login.php">Accede aquí</a>.
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/logout_estudiante.php
+++ b/logout_estudiante.php
@@ -1,0 +1,13 @@
+<?php
+session_start();
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+
+session_destroy();
+
+header('Location: login_estudiante.php');
+exit;

--- a/perfil_estudiante.php
+++ b/perfil_estudiante.php
@@ -1,0 +1,102 @@
+<?php
+require_once 'includes/db.php';
+require_once 'includes/protect_estudiante.php';
+include 'includes/header_estudiante.php';
+
+$estudiante_id = (int)($_SESSION['estudiante_id'] ?? 0);
+
+$stmt = $conn->prepare('SELECT e.id, e.nombre, e.avatar, e.usuario, e.clave_acceso, e.actividad_id, a.nombre AS actividad_nombre FROM estudiantes e INNER JOIN actividades a ON a.id = e.actividad_id WHERE e.id = ? LIMIT 1');
+$stmt->bind_param('i', $estudiante_id);
+$stmt->execute();
+$estudiante = $stmt->get_result()->fetch_assoc();
+
+if (!$estudiante) {
+    echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-emoji-frown'></i></div><h4 class='fw-semibold mb-2'>Perfil no disponible</h4><p class='text-muted mb-0'>No encontramos tu registro. Por favor, contacta a tu docente.</p></div></div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$resPuntaje = $conn->query('SELECT COALESCE(SUM(puntaje),0) AS total FROM puntuaciones WHERE estudiante_id='.$estudiante_id);
+$puntajeTotal = $resPuntaje ? (int)$resPuntaje->fetch_assoc()['total'] : 0;
+
+$retosStmt = $conn->prepare('SELECT id, nombre, descripcion FROM retos WHERE actividad_id = ? ORDER BY id DESC');
+$retosStmt->bind_param('i', $estudiante['actividad_id']);
+$retosStmt->execute();
+$retos = $retosStmt->get_result();
+
+$retroConteo = [];
+$retroRes = $conn->prepare('SELECT reto_id, COUNT(*) AS total FROM retroalimentaciones WHERE estudiante_id = ? GROUP BY reto_id');
+$retroRes->bind_param('i', $estudiante_id);
+$retroRes->execute();
+$retroData = $retroRes->get_result();
+while ($fila = $retroData->fetch_assoc()) {
+    $retroConteo[(int)$fila['reto_id']] = (int)$fila['total'];
+}
+?>
+
+<section class="page-header card border-0 shadow-sm mb-4">
+  <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+    <div>
+      <h1 class="page-title mb-1"><i class="bi bi-person-video3"></i> Mi espacio de aprendizaje</h1>
+      <p class="page-subtitle mb-0">Actividad asignada: <span class="fw-semibold text-dark"><?= htmlspecialchars($estudiante['actividad_nombre']) ?></span>.</p>
+    </div>
+    <div class="list-actions justify-content-lg-end">
+      <a href="logout_estudiante.php" class="btn btn-outline-light btn-icon"><i class="bi bi-box-arrow-right"></i> Cerrar sesión</a>
+    </div>
+  </div>
+</section>
+
+<div class="row g-4 mb-4">
+  <div class="col-lg-4">
+    <div class="card section-card h-100">
+      <div class="card-body text-center">
+        <img src="assets/img/avatars/<?= htmlspecialchars($estudiante['avatar']) ?>" class="avatar-xl shadow-sm mb-3" alt="Avatar de <?= htmlspecialchars($estudiante['nombre']) ?>">
+        <h3 class="fw-semibold mb-1"><?= htmlspecialchars($estudiante['nombre']) ?></h3>
+        <p class="text-muted mb-3">Grupo: <?= htmlspecialchars($estudiante['actividad_nombre']) ?></p>
+        <div class="badge rounded-pill text-bg-primary-subtle px-3 py-2 mb-3"><i class="bi bi-stars me-1"></i> <?= $puntajeTotal ?> puntos</div>
+        <div class="credential-box p-3 rounded">
+          <p class="text-muted text-uppercase small mb-2">Mis credenciales</p>
+          <div class="d-flex flex-column gap-2">
+            <span class="credential-chip"><i class="bi bi-person-circle me-2"></i><strong>Usuario:</strong> <?= htmlspecialchars($estudiante['usuario']) ?></span>
+            <span class="credential-chip"><i class="bi bi-key me-2"></i><strong>Clave:</strong> <?= htmlspecialchars($estudiante['clave_acceso']) ?></span>
+          </div>
+          <p class="form-text mt-2 mb-0">Si olvidas tus datos, solicita ayuda a tu docente.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-8">
+    <div class="card section-card h-100">
+      <div class="card-body">
+        <div class="d-flex align-items-center justify-content-between mb-3">
+          <h2 class="h4 fw-semibold mb-0"><i class="bi bi-flag"></i> Retos disponibles</h2>
+          <span class="badge rounded-pill bg-primary-subtle text-primary"><i class="bi bi-lightbulb me-1"></i>Aprendizaje activo</span>
+        </div>
+        <?php if ($retos->num_rows === 0): ?>
+          <div class="empty-state">
+            <i class="bi bi-emoji-smile"></i>
+            <p class="mb-0">Tu docente aún no ha publicado retos. ¡Mantente atento!</p>
+          </div>
+        <?php else: ?>
+          <div class="list-group list-group-flush">
+            <?php while ($reto = $retos->fetch_assoc()): ?>
+              <a class="list-group-item list-group-item-action py-3 reto-list-item" href="reto_estudiante.php?id=<?= $reto['id'] ?>">
+                <div class="d-flex justify-content-between align-items-start">
+                  <div>
+                    <h3 class="h5 fw-semibold mb-1 text-dark"><?= htmlspecialchars($reto['nombre']) ?></h3>
+                    <p class="text-muted mb-0 small"><?= htmlspecialchars(mb_strimwidth($reto['descripcion'] ?? 'Sin descripción', 0, 160, '…')) ?></p>
+                  </div>
+                  <div class="text-end ms-3">
+                    <span class="badge rounded-pill bg-secondary-subtle text-secondary"><i class="bi bi-chat-dots me-1"></i><?= $retroConteo[$reto['id']] ?? 0 ?> mensajes</span>
+                  </div>
+                </div>
+              </a>
+            <?php endwhile; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/reto_detalle.php
+++ b/reto_detalle.php
@@ -46,6 +46,11 @@ if (!$reto) {
 
 $video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
 $contenido_blog = limpiarContenidoBlog($reto['contenido_blog'] ?? null);
+
+$retroStmt = $conn->prepare('SELECT r.id, r.mensaje, r.archivo, r.autor, r.creado_en, e.nombre AS estudiante_nombre FROM retroalimentaciones r INNER JOIN estudiantes e ON e.id = r.estudiante_id WHERE r.reto_id = ? ORDER BY r.creado_en DESC');
+$retroStmt->bind_param('i', $reto_id);
+$retroStmt->execute();
+$retroalimentaciones = $retroStmt->get_result();
 ?>
 <section class="page-header card border-0 shadow-sm mb-4">
   <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
@@ -114,6 +119,38 @@ $contenido_blog = limpiarContenidoBlog($reto['contenido_blog'] ?? null);
     <?php endif; ?>
   </div>
 </div>
+
+<?php if ($retroalimentaciones->num_rows > 0): ?>
+  <div class="card section-card mt-4">
+    <div class="card-body">
+      <div class="d-flex justify-content-between align-items-center mb-3">
+        <h2 class="h4 fw-semibold mb-0"><i class="bi bi-chat-square-text"></i> Retroalimentaciones de estudiantes</h2>
+        <span class="badge rounded-pill bg-primary-subtle text-primary"><i class="bi bi-people"></i> <?= $retroalimentaciones->num_rows ?> registros</span>
+      </div>
+      <div class="timeline-feedback">
+        <?php while ($retro = $retroalimentaciones->fetch_assoc()): ?>
+          <div class="timeline-item">
+            <div class="timeline-dot <?= $retro['autor'] === 'docente' ? 'bg-primary' : '' ?>"></div>
+            <div class="timeline-content">
+              <div class="d-flex justify-content-between align-items-center mb-1">
+                <span class="fw-semibold text-dark"><i class="bi <?= $retro['autor'] === 'docente' ? 'bi-mortarboard-fill' : 'bi-person-badge-fill' ?> me-1"></i><?= htmlspecialchars($retro['autor'] === 'docente' ? 'Docente' : $retro['estudiante_nombre']) ?></span>
+                <span class="text-muted small"><i class="bi bi-clock-history me-1"></i><?= $retro['creado_en'] ?></span>
+              </div>
+              <?php if (!empty($retro['mensaje'])): ?>
+                <p class="mb-2"><?= nl2br(htmlspecialchars($retro['mensaje'])) ?></p>
+              <?php endif; ?>
+              <?php if (!empty($retro['archivo'])): ?>
+                <a class="btn btn-sm btn-outline-secondary btn-icon" href="assets/retroalimentaciones/<?= htmlspecialchars($retro['archivo']) ?>" target="_blank" rel="noopener"><i class="bi bi-paperclip"></i> Ver adjunto</a>
+              <?php endif; ?>
+            </div>
+          </div>
+        <?php endwhile; ?>
+      </div>
+    </div>
+  </div>
+<?php else: ?>
+  <div class="alert alert-secondary mt-4"><i class="bi bi-chat-square-dots me-2"></i>Aún no hay retroalimentaciones registradas para este reto.</div>
+<?php endif; ?>
 
 <style>
   .badge.text-bg-primary-soft {

--- a/reto_estudiante.php
+++ b/reto_estudiante.php
@@ -1,0 +1,249 @@
+<?php
+require_once 'includes/db.php';
+require_once 'includes/protect_estudiante.php';
+include 'includes/header_estudiante.php';
+
+function obtenerEmbedYoutube(?string $url): ?string {
+    if (!$url) {
+        return null;
+    }
+    $patron = '/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/|v\/))([A-Za-z0-9_-]{11})/';
+    if (preg_match($patron, $url, $coincidencias)) {
+        return 'https://www.youtube.com/embed/'.$coincidencias[1];
+    }
+    return null;
+}
+
+function limpiarContenidoBlog(?string $html): string {
+    if ($html === null) {
+        return '';
+    }
+    $permitidos = '<p><a><strong><em><u><ol><ul><li><h1><h2><h3><h4><h5><h6><blockquote><img><figure><figcaption><table><thead><tbody><tr><th><td><span><br><hr><pre><code><div>';
+    $sanitizado = strip_tags($html, $permitidos);
+    $sanitizado = preg_replace('/on\w+\s*=\s*("|\').*?\1/i', '', $sanitizado);
+    $sanitizado = preg_replace('/(href|src)\s*=\s*"javascript:[^"]*"/i', '$1="#"', $sanitizado);
+    $sanitizado = preg_replace("/(href|src)\s*=\s*'javascript:[^']*'/i", "$1='#'", $sanitizado);
+    return $sanitizado;
+}
+
+$estudiante_id = (int)($_SESSION['estudiante_id'] ?? 0);
+$reto_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+
+if ($reto_id <= 0) {
+    echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-flag'></i></div><h4 class='fw-semibold mb-2'>Reto no válido</h4><p class='text-muted mb-0'>Regresa a tu <a href='perfil_estudiante.php'>panel</a> para seleccionar un reto disponible.</p></div></div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$stmt = $conn->prepare('SELECT r.id, r.nombre, r.descripcion, r.contenido_blog, r.imagen, r.video_url, r.pdf, a.id AS actividad_id, a.nombre AS actividad_nombre, e.nombre AS estudiante_nombre FROM retos r INNER JOIN actividades a ON r.actividad_id = a.id INNER JOIN estudiantes e ON e.actividad_id = a.id WHERE r.id = ? AND e.id = ?');
+$stmt->bind_param('ii', $reto_id, $estudiante_id);
+$stmt->execute();
+$reto = $stmt->get_result()->fetch_assoc();
+
+if (!$reto) {
+    echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-search'></i></div><h4 class='fw-semibold mb-2'>Reto no encontrado</h4><p class='text-muted mb-0'>Es posible que no pertenezca a tu actividad. Consulta con tu docente.</p></div></div>";
+    include 'includes/footer.php';
+    exit;
+}
+
+$errores = [];
+$exito = $_SESSION['retro_exito'] ?? null;
+unset($_SESSION['retro_exito']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $mensaje = trim($_POST['mensaje'] ?? '');
+    $archivoNombre = null;
+
+    if (!empty($_FILES['adjunto']['name'])) {
+        $permitidos = ['jpg','jpeg','png','gif','pdf','doc','docx','ppt','pptx','zip'];
+        $ext = strtolower(pathinfo($_FILES['adjunto']['name'], PATHINFO_EXTENSION));
+
+        if (!in_array($ext, $permitidos)) {
+            $errores[] = 'El archivo adjunto no es compatible. Usa imágenes, PDF o documentos.';
+        } else {
+            $directorio = 'assets/retroalimentaciones';
+            if (!is_dir($directorio)) {
+                mkdir($directorio, 0775, true);
+            }
+            $archivoNombre = 'retro_'.$estudiante_id.'_'.time().'_'.bin2hex(random_bytes(3)).'.'.$ext;
+            $rutaDestino = $directorio.'/'.$archivoNombre;
+            if (!move_uploaded_file($_FILES['adjunto']['tmp_name'], $rutaDestino)) {
+                $errores[] = 'No se pudo guardar el archivo adjunto.';
+                $archivoNombre = null;
+            }
+        }
+    }
+
+    if ($mensaje === '' && !$archivoNombre) {
+        $errores[] = 'Escribe un mensaje o adjunta un archivo para enviar tu retroalimentación.';
+    }
+
+    if (!$errores) {
+        $stmtInsert = $conn->prepare('INSERT INTO retroalimentaciones (estudiante_id, reto_id, mensaje, archivo, autor) VALUES (?, ?, ?, ?, ?)');
+
+        if (!$stmtInsert) {
+            error_log('Error al preparar retroalimentación de estudiante: '.$conn->error);
+            $errores[] = 'No se pudo registrar tu retroalimentación. Intenta nuevamente en unos minutos.';
+        } else {
+            $autorRetro = 'estudiante';
+            if ($stmtInsert->bind_param('iisss', $estudiante_id, $reto_id, $mensaje, $archivoNombre, $autorRetro)) {
+                if ($stmtInsert->execute()) {
+                    $_SESSION['retro_exito'] = '¡Tu retroalimentación fue enviada!';
+                    $stmtInsert->close();
+                    header('Location: reto_estudiante.php?id='.$reto_id);
+                    exit;
+                }
+
+                error_log('Error al guardar retroalimentación de estudiante: '.$stmtInsert->error);
+                $errores[] = 'No se pudo registrar tu retroalimentación. Intenta nuevamente en unos minutos.';
+            } else {
+                error_log('Error al vincular parámetros de retroalimentación de estudiante: '.$stmtInsert->error);
+                $errores[] = 'No se pudo registrar tu retroalimentación. Intenta nuevamente en unos minutos.';
+            }
+
+            $stmtInsert->close();
+        }
+    }
+}
+
+$video_embed = obtenerEmbedYoutube($reto['video_url'] ?? null);
+$contenido_blog = limpiarContenidoBlog($reto['contenido_blog'] ?? null);
+
+$retroStmt = $conn->prepare('SELECT id, mensaje, archivo, autor, creado_en FROM retroalimentaciones WHERE reto_id = ? AND estudiante_id = ? ORDER BY creado_en DESC');
+$retroStmt->bind_param('ii', $reto_id, $estudiante_id);
+$retroStmt->execute();
+$retroalimentaciones = $retroStmt->get_result();
+?>
+
+<section class="page-header card border-0 shadow-sm mb-4">
+  <div class="card-body d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3">
+    <div>
+      <h1 class="page-title mb-1"><i class="bi bi-flag"></i> <?= htmlspecialchars($reto['nombre']) ?></h1>
+      <p class="page-subtitle mb-0">Actividad: <span class="fw-semibold text-dark"><?= htmlspecialchars($reto['actividad_nombre']) ?></span></p>
+    </div>
+    <div class="list-actions justify-content-lg-end">
+      <a href="perfil_estudiante.php" class="btn btn-outline-primary btn-icon"><i class="bi bi-arrow-left"></i> Volver</a>
+    </div>
+  </div>
+</section>
+
+<?php if ($exito): ?>
+  <div class="alert alert-success alert-dismissible fade show" role="alert">
+    <i class="bi bi-check-circle-fill me-2"></i><?= htmlspecialchars($exito) ?>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Cerrar"></button>
+  </div>
+<?php endif; ?>
+
+<?php if ($errores): ?>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <?php foreach ($errores as $error): ?>
+        <li><?= htmlspecialchars($error) ?></li>
+      <?php endforeach; ?>
+    </ul>
+  </div>
+<?php endif; ?>
+
+<article class="card border-0 shadow-sm overflow-hidden mb-4">
+  <?php if (!empty($reto['imagen'])): ?>
+    <div class="ratio ratio-21x9 bg-dark">
+      <img src="<?= htmlspecialchars($reto['imagen']) ?>" alt="Imagen destacada del reto" class="w-100 h-100" style="object-fit: cover;">
+    </div>
+  <?php else: ?>
+    <div class="bg-gradient p-5 text-center text-white" style="background: linear-gradient(135deg, #6366f1, #22d3ee);">
+      <i class="bi bi-stars display-4"></i>
+    </div>
+  <?php endif; ?>
+  <div class="card-body p-4 p-lg-5">
+    <span class="badge text-bg-primary-soft text-uppercase mb-3">Reto académico</span>
+    <h2 class="fw-bold text-dark mb-3">Descripción</h2>
+    <p class="lead text-muted mb-4"><?= nl2br(htmlspecialchars($reto['descripcion'] ?? '')) ?: '<span class="fst-italic">Sin descripción registrada</span>' ?></p>
+    <?php if ($contenido_blog !== ''): ?>
+      <div class="blog-content mb-4">
+        <?= $contenido_blog ?>
+      </div>
+    <?php endif; ?>
+
+    <?php if ($video_embed || !empty($reto['video_url'])): ?>
+      <section class="mb-4">
+        <h3 class="h5 fw-semibold mb-3"><i class="bi bi-camera-video"></i> Video de referencia</h3>
+        <?php if ($video_embed): ?>
+          <div class="ratio ratio-16x9 rounded overflow-hidden shadow-sm">
+            <iframe src="<?= htmlspecialchars($video_embed) ?>" title="Video del reto" allowfullscreen></iframe>
+          </div>
+        <?php else: ?>
+          <a href="<?= htmlspecialchars($reto['video_url']) ?>" target="_blank" rel="noopener" class="btn btn-outline-primary btn-icon"><i class="bi bi-play-circle"></i> Ver video</a>
+        <?php endif; ?>
+      </section>
+    <?php endif; ?>
+
+    <?php if (!empty($reto['pdf'])): ?>
+      <section class="mb-4">
+        <h3 class="h5 fw-semibold mb-3"><i class="bi bi-file-earmark-pdf"></i> Documento descargable</h3>
+        <div class="ratio ratio-16x9 rounded overflow-hidden shadow-sm mb-3">
+          <iframe src="<?= htmlspecialchars($reto['pdf']) ?>" title="PDF del reto"></iframe>
+        </div>
+        <a href="<?= htmlspecialchars($reto['pdf']) ?>" class="btn btn-outline-secondary btn-icon" target="_blank" rel="noopener"><i class="bi bi-download"></i> Descargar PDF</a>
+      </section>
+    <?php endif; ?>
+  </div>
+</article>
+
+<div class="row g-4 mb-5">
+  <div class="col-lg-6">
+    <div class="card section-card h-100">
+      <div class="card-body">
+        <h2 class="h4 fw-semibold mb-3"><i class="bi bi-chat-dots"></i> Enviar retroalimentación</h2>
+        <form method="post" enctype="multipart/form-data" class="d-flex flex-column gap-3">
+          <div>
+            <label for="mensaje" class="form-label">Mensaje</label>
+            <textarea id="mensaje" name="mensaje" class="form-control" rows="5" placeholder="Cuéntale a tu docente cómo avanzaste o qué dudas tienes."><?= htmlspecialchars($_POST['mensaje'] ?? '') ?></textarea>
+          </div>
+          <div>
+            <label for="adjunto" class="form-label">Archivo adjunto (opcional)</label>
+            <input type="file" id="adjunto" name="adjunto" class="form-control" accept="image/*,.pdf,.doc,.docx,.ppt,.pptx,.zip">
+            <div class="form-text">Adjunta evidencias, fotos o documentos de tu trabajo.</div>
+          </div>
+          <div class="d-grid">
+            <button class="btn btn-primary btn-icon"><i class="bi bi-send"></i> Enviar</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="col-lg-6">
+    <div class="card section-card h-100">
+      <div class="card-body">
+        <h2 class="h4 fw-semibold mb-3"><i class="bi bi-archive"></i> Historial</h2>
+        <?php if ($retroalimentaciones->num_rows === 0): ?>
+          <div class="empty-state">
+            <i class="bi bi-hourglass-split"></i>
+            <p class="mb-0">Aún no envías comentarios. ¡Comparte tus avances!</p>
+          </div>
+        <?php else: ?>
+          <div class="timeline-feedback">
+            <?php while ($retro = $retroalimentaciones->fetch_assoc()): ?>
+              <div class="timeline-item">
+                <div class="timeline-dot <?= $retro['autor'] === 'docente' ? 'bg-primary' : 'bg-success' ?>"></div>
+                <div class="timeline-content">
+                  <div class="d-flex justify-content-between align-items-center mb-1">
+                    <span class="fw-semibold text-dark"><i class="bi <?= $retro['autor'] === 'docente' ? 'bi-mortarboard-fill' : 'bi-person-check-fill' ?> me-1"></i><?= $retro['autor'] === 'docente' ? 'Docente' : 'Tú' ?></span>
+                    <span class="text-muted small"><i class="bi bi-clock-history me-1"></i><?= $retro['creado_en'] ?></span>
+                  </div>
+                  <?php if (!empty($retro['mensaje'])): ?>
+                    <p class="mb-2"><?= nl2br(htmlspecialchars($retro['mensaje'])) ?></p>
+                  <?php endif; ?>
+                  <?php if (!empty($retro['archivo'])): ?>
+                    <a class="btn btn-sm btn-outline-secondary btn-icon" href="assets/retroalimentaciones/<?= htmlspecialchars($retro['archivo']) ?>" target="_blank" rel="noopener"><i class="bi bi-paperclip"></i> Ver adjunto</a>
+                  <?php endif; ?>
+                </div>
+              </div>
+            <?php endwhile; ?>
+          </div>
+        <?php endif; ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<?php include 'includes/footer.php'; ?>

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -24,7 +24,11 @@ CREATE TABLE IF NOT EXISTS estudiantes (
   nombre VARCHAR(100) NOT NULL,
   avatar VARCHAR(255) DEFAULT 'default.png',
   actividad_id INT NOT NULL,
-  CONSTRAINT fk_est_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE
+  usuario VARCHAR(60) NOT NULL,
+  clave_acceso VARCHAR(120) NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  CONSTRAINT fk_est_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE,
+  UNIQUE KEY uniq_usuario_estudiante (usuario)
 ) ENGINE=InnoDB;
 
 -- Habilidades
@@ -55,6 +59,19 @@ CREATE TABLE IF NOT EXISTS retos (
   video_url VARCHAR(255),
   pdf VARCHAR(255),
   CONSTRAINT fk_reto_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+-- Retroalimentaciones entre estudiantes y docentes
+CREATE TABLE IF NOT EXISTS retroalimentaciones (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  estudiante_id INT NOT NULL,
+  reto_id INT NOT NULL,
+  mensaje TEXT,
+  archivo VARCHAR(255),
+  autor ENUM('estudiante','docente') DEFAULT 'estudiante',
+  creado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_retro_est FOREIGN KEY (estudiante_id) REFERENCES estudiantes(id) ON DELETE CASCADE,
+  CONSTRAINT fk_retro_reto FOREIGN KEY (reto_id) REFERENCES retos(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 -- Semillas de habilidades


### PR DESCRIPTION
## Resumen
- Resolver el conflicto de `reto_estudiante.php` conservando la inserción segura de retroalimentaciones por parte del estudiante.
- Añadir manejo de errores en el enlace de parámetros y cerrar siempre la sentencia preparada para evitar fugas de recursos.
- Reestructurar el flujo de inserción de retroalimentaciones para evitar el error de análisis y mantener el control de errores en la ejecución.

## Pruebas
- php -l reto_estudiante.php

------
https://chatgpt.com/codex/tasks/task_e_68d57a920078832686de4a8695a5fbad