### PR TITLE
Allow assigning students to multiple activities and add teacher feedback replies

### DIFF
--- a/actividades.php
+++ b/actividades.php
@@ -3,15 +3,101 @@ require_once 'includes/db.php';
 require_once 'includes/protect.php';
 include 'includes/header.php';
 
+function sincronizarEstudiantesActividad(mysqli $conn, int $actividadId, array $idsNuevos): void {
+  $idsNuevos = array_values(array_unique(array_filter(array_map('intval', $idsNuevos))));
+
+  $actuales = [];
+  $stmtActuales = $conn->prepare('SELECT estudiante_id FROM actividad_estudiante WHERE actividad_id = ?');
+  $stmtActuales->bind_param('i', $actividadId);
+  $stmtActuales->execute();
+  $resActuales = $stmtActuales->get_result();
+  while ($fila = $resActuales->fetch_assoc()) {
+    $actuales[] = (int)$fila['estudiante_id'];
+  }
+  $stmtActuales->close();
+
+  $agregar = array_diff($idsNuevos, $actuales);
+  $quitar = array_diff($actuales, $idsNuevos);
+
+  if ($agregar) {
+    $stmtInsert = $conn->prepare('INSERT INTO actividad_estudiante (actividad_id, estudiante_id) VALUES (?, ?)');
+    foreach ($agregar as $estId) {
+      $stmtInsert->bind_param('ii', $actividadId, $estId);
+      if (!$stmtInsert->execute()) {
+        throw new RuntimeException('No se pudo asignar un estudiante a la actividad.');
+      }
+    }
+    $stmtInsert->close();
+  }
+
+  if ($quitar) {
+    $stmtDeleteRelacion = $conn->prepare('DELETE FROM actividad_estudiante WHERE actividad_id = ? AND estudiante_id = ?');
+    $stmtDeletePuntajes = $conn->prepare('DELETE FROM puntuaciones WHERE actividad_id = ? AND estudiante_id = ?');
+    $stmtDeleteRetro = $conn->prepare('DELETE r FROM retroalimentaciones r INNER JOIN retos rt ON rt.id = r.reto_id WHERE r.estudiante_id = ? AND rt.actividad_id = ?');
+
+    foreach ($quitar as $estId) {
+      $stmtDeleteRelacion->bind_param('ii', $actividadId, $estId);
+      if (!$stmtDeleteRelacion->execute()) {
+        throw new RuntimeException('No se pudo quitar un estudiante de la actividad.');
+      }
+
+      $stmtDeletePuntajes->bind_param('ii', $actividadId, $estId);
+      $stmtDeletePuntajes->execute();
+
+      $stmtDeleteRetro->bind_param('ii', $estId, $actividadId);
+      $stmtDeleteRetro->execute();
+    }
+
+    $stmtDeleteRelacion->close();
+    $stmtDeletePuntajes->close();
+    $stmtDeleteRetro->close();
+  }
+}
+
+function obtenerEstudiantesAsignados(mysqli $conn, int $actividadId): array {
+  $asignados = [];
+  $stmt = $conn->prepare('SELECT estudiante_id FROM actividad_estudiante WHERE actividad_id = ?');
+  $stmt->bind_param('i', $actividadId);
+  $stmt->execute();
+  $res = $stmt->get_result();
+  while ($fila = $res->fetch_assoc()) {
+    $asignados[] = (int)$fila['estudiante_id'];
+  }
+  $stmt->close();
+  return $asignados;
+}
+
+$errorActividad = null;
+
 // Crear actividad
+$estudiantesSeleccionados = [];
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['nombre']) && empty($_POST['actividad_id'])) {
   $nombre = trim($_POST['nombre']);
+  $estudiantesSeleccionados = array_map('intval', $_POST['estudiantes_asignados'] ?? []);
+
   if ($nombre !== '') {
-    $stmt = $conn->prepare("INSERT INTO actividades (nombre) VALUES (?)");
-    $stmt->bind_param("s", $nombre);
-    $stmt->execute();
+    $conn->begin_transaction();
+    try {
+      $stmt = $conn->prepare("INSERT INTO actividades (nombre) VALUES (?)");
+      $stmt->bind_param("s", $nombre);
+      if (!$stmt->execute()) {
+        throw new RuntimeException('No se pudo crear la actividad.');
+      }
+      $actividadId = $conn->insert_id;
+      $stmt->close();
+
+      sincronizarEstudiantesActividad($conn, $actividadId, $estudiantesSeleccionados);
+
+      $conn->commit();
+      header("Location: actividades.php");
+      exit;
+    } catch (Throwable $e) {
+      $conn->rollback();
+      $errorActividad = 'No se pudo crear la actividad. Intenta nuevamente.';
+    }
+  } else {
+    $errorActividad = 'Ingresa un nombre para la actividad.';
   }
-  header("Location: actividades.php"); exit;
 }
 
 // Editar actividad
@@ -22,17 +108,41 @@ if (isset($_GET['editar'])) {
   $stmt->bind_param("i", $editarId);
   $stmt->execute();
   $actividadEdit = $stmt->get_result()->fetch_assoc();
+  $stmt->close();
+  if ($actividadEdit) {
+    $estudiantesSeleccionados = obtenerEstudiantesAsignados($conn, (int)$actividadEdit['id']);
+  }
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['actividad_id']) && !empty($_POST['actividad_id'])) {
   $actividadId = (int)$_POST['actividad_id'];
   $nombre = trim($_POST['nombre']);
+  $estudiantesSeleccionados = array_map('intval', $_POST['estudiantes_asignados'] ?? []);
+
   if ($nombre !== '') {
-    $stmt = $conn->prepare("UPDATE actividades SET nombre=? WHERE id=?");
-    $stmt->bind_param("si", $nombre, $actividadId);
-    $stmt->execute();
+    $conn->begin_transaction();
+    try {
+      $stmt = $conn->prepare("UPDATE actividades SET nombre=? WHERE id=?");
+      $stmt->bind_param("si", $nombre, $actividadId);
+      if (!$stmt->execute()) {
+        throw new RuntimeException('No se pudo actualizar la actividad.');
+      }
+      $stmt->close();
+
+      sincronizarEstudiantesActividad($conn, $actividadId, $estudiantesSeleccionados);
+
+      $conn->commit();
+      header("Location: actividades.php");
+      exit;
+    } catch (Throwable $e) {
+      $conn->rollback();
+      $errorActividad = 'No se pudo actualizar la actividad. Intenta nuevamente.';
+      $actividadEdit = ['id' => $actividadId, 'nombre' => $nombre];
+    }
+  } else {
+    $errorActividad = 'Ingresa un nombre para la actividad.';
+    $actividadEdit = ['id' => $actividadId, 'nombre' => $nombre];
   }
-  header("Location: actividades.php"); exit;
 }
 
 // Eliminar
@@ -40,6 +150,15 @@ if (isset($_GET['eliminar'])) {
   $id = (int)$_GET['eliminar'];
   $conn->query("DELETE FROM actividades WHERE id=$id");
   header("Location: actividades.php"); exit;
+}
+
+$listaEstudiantes = [];
+$resEstudiantes = $conn->query('SELECT id, nombre, usuario FROM estudiantes ORDER BY nombre ASC');
+if ($resEstudiantes) {
+  while ($fila = $resEstudiantes->fetch_assoc()) {
+    $listaEstudiantes[] = $fila;
+  }
+  $resEstudiantes->close();
 }
 
 $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY id DESC");
@@ -60,6 +179,12 @@ $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY
   <div class="alert alert-info shadow-sm">Editando actividad <strong><?= htmlspecialchars($actividadEdit['nombre']) ?></strong>. <a href="actividades.php" class="alert-link">Cancelar</a></div>
 <?php endif; ?>
 
+<?php if ($errorActividad): ?>
+  <div class="alert alert-danger shadow-sm">
+    <i class="bi bi-exclamation-triangle me-2"></i><?= htmlspecialchars($errorActividad) ?>
+  </div>
+<?php endif; ?>
+
 <form method="post" class="card border-0 shadow-sm mb-4">
   <input type="hidden" name="actividad_id" value="<?= $actividadEdit['id'] ?? '' ?>">
   <div class="card-body">
@@ -76,6 +201,24 @@ $res = $conn->query("SELECT id, nombre, fecha_creacion FROM actividades ORDER BY
           <i class="bi <?= $actividadEdit ? 'bi-arrow-repeat' : 'bi-plus-circle' ?> me-2"></i>
           <?= $actividadEdit ? 'Actualizar actividad' : 'Crear actividad' ?>
         </button>
+      </div>
+    </div>
+    <div class="row g-3 align-items-center mt-1">
+      <div class="col-12">
+        <label for="estudiantes_asignados" class="form-label fw-semibold">Asignar estudiantes existentes</label>
+        <select id="estudiantes_asignados" name="estudiantes_asignados[]" class="form-select" multiple size="6" <?= $listaEstudiantes ? '' : 'disabled' ?> aria-describedby="ayuda-estudiantes-asignados">
+          <?php foreach ($listaEstudiantes as $est): ?>
+            <?php $seleccionado = in_array((int)$est['id'], $estudiantesSeleccionados, true) ? 'selected' : ''; ?>
+            <option value="<?= $est['id'] ?>" <?= $seleccionado ?>><?= htmlspecialchars($est['nombre']) ?> (<?= htmlspecialchars($est['usuario']) ?>)</option>
+          <?php endforeach; ?>
+        </select>
+        <div class="form-text" id="ayuda-estudiantes-asignados">
+          <?php if ($listaEstudiantes): ?>
+            Mantén presionadas las teclas Ctrl o Cmd para elegir varios estudiantes. También puedes agregarlos más tarde desde la sección de estudiantes.
+          <?php else: ?>
+            Aún no hay estudiantes registrados. Podrás asignarlos después desde la sección de estudiantes.
+          <?php endif; ?>
+        </div>
       </div>
     </div>
   </div>

--- a/login_estudiante.php
+++ b/login_estudiante.php
@@ -19,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($usuario === '' || $clave === '') {
         $errores[] = 'Ingresa tu usuario y clave de acceso.';
     } else {
-        $stmt = $conn->prepare('SELECT id, nombre, actividad_id, clave_acceso, password_hash FROM estudiantes WHERE usuario = ? LIMIT 1');
+        $stmt = $conn->prepare('SELECT id, nombre, clave_acceso, password_hash FROM estudiantes WHERE usuario = ? LIMIT 1');
         $stmt->bind_param('s', $usuario);
         $stmt->execute();
         $resultado = $stmt->get_result();
@@ -42,7 +42,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($credencialValida) {
                 $_SESSION['estudiante_id'] = $estudiante['id'];
                 $_SESSION['estudiante_nombre'] = $estudiante['nombre'];
-                $_SESSION['estudiante_actividad_id'] = $estudiante['actividad_id'];
                 header('Location: perfil_estudiante.php');
                 exit;
             }

--- a/puntuar.php
+++ b/puntuar.php
@@ -29,9 +29,10 @@ $retos=$stmt->get_result();
 
 // Estudiantes con totales
 $q = "SELECT e.id, e.nombre, e.avatar, COALESCE(SUM(p.puntaje),0) AS total "
-   . "FROM estudiantes e "
-   . "LEFT JOIN puntuaciones p ON p.estudiante_id=e.id "
-   . "WHERE e.actividad_id=? "
+   . "FROM actividad_estudiante ae "
+   . "INNER JOIN estudiantes e ON e.id = ae.estudiante_id "
+   . "LEFT JOIN puntuaciones p ON p.estudiante_id = e.id AND p.actividad_id = ae.actividad_id "
+   . "WHERE ae.actividad_id=? "
    . "GROUP BY e.id, e.nombre, e.avatar "
    . "ORDER BY total DESC, e.nombre ASC";
 $stmt=$conn->prepare($q);
@@ -106,7 +107,7 @@ $estudiantes=$stmt->get_result();
             <p class="text-muted mb-2">Puntos acumulados</p>
             <span class="badge bg-primary fs-6"><i class="bi bi-stars me-1"></i><?= $e['total'] ?></span>
           </div>
-          <a href="puntuar_estudiante.php?id=<?= $e['id'] ?>" class="btn btn-success btn-icon"><i class="bi bi-plus-circle"></i> Puntuar</a>
+          <a href="puntuar_estudiante.php?id=<?= $e['id'] ?>&actividad_id=<?= $actividad_id ?>" class="btn btn-success btn-icon"><i class="bi bi-plus-circle"></i> Puntuar</a>
         </div>
       </div>
     </div>

--- a/puntuar_estudiante.php
+++ b/puntuar_estudiante.php
@@ -4,15 +4,16 @@ require_once 'includes/protect.php';
 include 'includes/header.php';
 
 $estudiante_id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
-if ($estudiante_id<=0){
+$actividad_id = isset($_GET['actividad_id']) ? (int)$_GET['actividad_id'] : 0;
+if ($estudiante_id<=0 || $actividad_id<=0){
   echo "<div class='card section-card border-0 bg-white text-center p-4'><div class='card-body'><div class='auth-icon mx-auto mb-3'><i class='bi bi-exclamation-triangle'></i></div><h4 class='fw-semibold mb-2'>Estudiante no válido</h4><p class='text-muted mb-0'>Regresa al <a href='actividades.php'>tablero</a> y selecciona un perfil disponible.</p></div></div>";
   include 'includes/footer.php';
   exit;
 }
 
 // Estudiante + actividad
-$stmt=$conn->prepare("SELECT e.id, e.nombre, e.avatar, e.actividad_id, a.nombre AS actividad FROM estudiantes e JOIN actividades a ON a.id=e.actividad_id WHERE e.id=?");
-$stmt->bind_param("i",$estudiante_id);
+$stmt=$conn->prepare("SELECT e.id, e.nombre, e.avatar, a.id AS actividad_id, a.nombre AS actividad FROM actividad_estudiante ae INNER JOIN estudiantes e ON e.id = ae.estudiante_id INNER JOIN actividades a ON a.id = ae.actividad_id WHERE e.id=? AND a.id=?");
+$stmt->bind_param("ii",$estudiante_id,$actividad_id);
 $stmt->execute();
 $est=$stmt->get_result()->fetch_assoc();
 if(!$est){
@@ -20,6 +21,7 @@ if(!$est){
   include 'includes/footer.php';
   exit;
 }
+$stmt->close();
 
 // Habilidades
 $hab=$conn->query("SELECT id, nombre FROM habilidades ORDER BY id ASC");
@@ -31,7 +33,7 @@ $hab=$conn->query("SELECT id, nombre FROM habilidades ORDER BY id ASC");
       <p class="page-subtitle mb-0">Actividad: <span class="fw-semibold text-dark"><?= htmlspecialchars($est['actividad']) ?></span>. Reconoce los logros por habilidad.</p>
     </div>
     <div class="list-actions justify-content-lg-end">
-      <a href="puntuar.php?actividad_id=<?= $est['actividad_id'] ?>" class="btn btn-outline-primary btn-icon"><i class="bi bi-graph-up"></i> Volver al tablero</a>
+      <a href="puntuar.php?actividad_id=<?= $actividad_id ?>" class="btn btn-outline-primary btn-icon"><i class="bi bi-graph-up"></i> Volver al tablero</a>
     </div>
   </div>
 </section>
@@ -41,7 +43,7 @@ $hab=$conn->query("SELECT id, nombre FROM habilidades ORDER BY id ASC");
     <img src="assets/img/avatars/<?= htmlspecialchars($est['avatar']) ?>" class="avatar-xl shadow-sm" alt="avatar de <?= htmlspecialchars($est['nombre']) ?>">
     <div>
       <h3 class="fw-semibold mb-1"><?= htmlspecialchars($est['nombre']) ?></h3>
-      <?php $res=$conn->query("SELECT COALESCE(SUM(puntaje),0) AS total FROM puntuaciones WHERE estudiante_id=".$estudiante_id); $total=$res->fetch_assoc()['total']; ?>
+      <?php $stmtTotal=$conn->prepare('SELECT COALESCE(SUM(puntaje),0) AS total FROM puntuaciones WHERE estudiante_id=? AND actividad_id=?'); $stmtTotal->bind_param('ii',$estudiante_id,$actividad_id); $stmtTotal->execute(); $total=$stmtTotal->get_result()->fetch_assoc()['total'] ?? 0; $stmtTotal->close(); ?>
       <p class="text-muted mb-2">Puntos acumulados</p>
       <span class="badge bg-primary fs-5"><i class="bi bi-stars me-1"></i><?= $total ?></span>
     </div>
@@ -59,21 +61,26 @@ $hab=$conn->query("SELECT id, nombre FROM habilidades ORDER BY id ASC");
         </tr>
       </thead>
       <tbody>
+        <?php $stmtValor = $conn->prepare('SELECT puntaje FROM puntuaciones WHERE estudiante_id = ? AND habilidad_id = ? AND actividad_id = ?'); ?>
         <?php while($h=$hab->fetch_assoc()):
-          $r=$conn->query("SELECT puntaje FROM puntuaciones WHERE estudiante_id=$estudiante_id AND habilidad_id=".$h['id']);
-          $valor = ($r && $r->num_rows) ? (int)$r->fetch_assoc()['puntaje'] : 0;
+          $stmtValor->bind_param('iii', $estudiante_id, $h['id'], $actividad_id);
+          $stmtValor->execute();
+          $resultadoValor = $stmtValor->get_result();
+          $valor = ($resultadoValor && $resultadoValor->num_rows) ? (int)$resultadoValor->fetch_assoc()['puntaje'] : 0;
+          if ($resultadoValor) { $resultadoValor->free(); }
         ?>
         <tr>
           <td class="fw-semibold text-dark"><i class="bi bi-patch-check-fill text-primary me-2"></i><?= htmlspecialchars($h['nombre']) ?></td>
           <td>
             <div class="btn-group" role="group">
-              <a class="btn btn-sm btn-success btn-icon" href="update_puntaje.php?estudiante=<?= $estudiante_id ?>&habilidad=<?= $h['id'] ?>&accion=mas"><i class="bi bi-plus"></i> Añadir</a>
-              <a class="btn btn-sm btn-outline-danger btn-icon" href="update_puntaje.php?estudiante=<?= $estudiante_id ?>&habilidad=<?= $h['id'] ?>&accion=menos"><i class="bi bi-dash"></i> Restar</a>
+              <a class="btn btn-sm btn-success btn-icon" href="update_puntaje.php?estudiante=<?= $estudiante_id ?>&habilidad=<?= $h['id'] ?>&actividad=<?= $actividad_id ?>&accion=mas"><i class="bi bi-plus"></i> Añadir</a>
+              <a class="btn btn-sm btn-outline-danger btn-icon" href="update_puntaje.php?estudiante=<?= $estudiante_id ?>&habilidad=<?= $h['id'] ?>&actividad=<?= $actividad_id ?>&accion=menos"><i class="bi bi-dash"></i> Restar</a>
             </div>
           </td>
           <td class="text-end"><span class="badge bg-secondary fs-6"><i class="bi bi-activity me-1"></i><?= $valor ?></span></td>
         </tr>
         <?php endwhile; ?>
+        <?php $stmtValor->close(); ?>
       </tbody>
     </table>
   </div>

--- a/reto_estudiante.php
+++ b/reto_estudiante.php
@@ -37,7 +37,8 @@ $stmt = $conn->prepare('
            e.nombre AS estudiante_nombre
     FROM retos r
     INNER JOIN actividades a ON r.actividad_id = a.id
-    INNER JOIN estudiantes e ON e.actividad_id = a.id
+    INNER JOIN actividad_estudiante ae ON ae.actividad_id = a.id
+    INNER JOIN estudiantes e ON e.id = ae.estudiante_id
     WHERE r.id = ? AND e.id = ?
 ');
 $stmt->bind_param('ii', $reto_id, $estudiante_id);

--- a/sql/tablero_puntuaciones.sql
+++ b/sql/tablero_puntuaciones.sql
@@ -23,12 +23,21 @@ CREATE TABLE IF NOT EXISTS estudiantes (
   id INT AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(100) NOT NULL,
   avatar VARCHAR(255) DEFAULT 'default.png',
-  actividad_id INT NOT NULL,
   usuario VARCHAR(60) NOT NULL,
   clave_acceso VARCHAR(120) NOT NULL,
   password_hash VARCHAR(255) NOT NULL,
-  CONSTRAINT fk_est_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE,
+  creado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   UNIQUE KEY uniq_usuario_estudiante (usuario)
+) ENGINE=InnoDB;
+
+-- Relación actividades <-> estudiantes (muchos a muchos)
+CREATE TABLE IF NOT EXISTS actividad_estudiante (
+  actividad_id INT NOT NULL,
+  estudiante_id INT NOT NULL,
+  asignado_en TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (actividad_id, estudiante_id),
+  CONSTRAINT fk_act_est_actividad FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE,
+  CONSTRAINT fk_act_est_estudiante FOREIGN KEY (estudiante_id) REFERENCES estudiantes(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
 -- Habilidades
@@ -41,11 +50,13 @@ CREATE TABLE IF NOT EXISTS habilidades (
 CREATE TABLE IF NOT EXISTS puntuaciones (
   id INT AUTO_INCREMENT PRIMARY KEY,
   estudiante_id INT NOT NULL,
+  actividad_id INT NOT NULL,
   habilidad_id INT NOT NULL,
   puntaje INT NOT NULL DEFAULT 0,
   CONSTRAINT fk_punt_est FOREIGN KEY (estudiante_id) REFERENCES estudiantes(id) ON DELETE CASCADE,
+  CONSTRAINT fk_punt_act FOREIGN KEY (actividad_id) REFERENCES actividades(id) ON DELETE CASCADE,
   CONSTRAINT fk_punt_hab FOREIGN KEY (habilidad_id) REFERENCES habilidades(id) ON DELETE CASCADE,
-  UNIQUE KEY uniq_est_hab (estudiante_id, habilidad_id)
+  UNIQUE KEY uniq_est_act_hab (estudiante_id, actividad_id, habilidad_id)
 ) ENGINE=InnoDB;
 
 -- Retos por actividad (solo informativos en esta versión)

--- a/update_puntaje.php
+++ b/update_puntaje.php
@@ -4,22 +4,23 @@ require_once 'includes/protect.php';
 
 $estudiante = isset($_GET['estudiante']) ? (int)$_GET['estudiante'] : 0;
 $habilidad = isset($_GET['habilidad']) ? (int)$_GET['habilidad'] : 0;
+$actividad = isset($_GET['actividad']) ? (int)$_GET['actividad'] : 0;
 $accion = isset($_GET['accion']) ? $_GET['accion'] : '';
 
-if ($estudiante>0 && $habilidad>0 && in_array($accion,['mas','menos'])) {
+if ($estudiante>0 && $habilidad>0 && $actividad>0 && in_array($accion,['mas','menos'])) {
   $valor = ($accion==='mas') ? 1 : -1;
   $conn->begin_transaction();
   try {
-    $stmt=$conn->prepare("UPDATE puntuaciones SET puntaje = puntaje + ? WHERE estudiante_id=? AND habilidad_id=?");
-    $stmt->bind_param("iii",$valor,$estudiante,$habilidad);
+    $stmt=$conn->prepare("UPDATE puntuaciones SET puntaje = puntaje + ? WHERE estudiante_id=? AND habilidad_id=? AND actividad_id=?");
+    $stmt->bind_param("iiii",$valor,$estudiante,$habilidad,$actividad);
     $stmt->execute();
     if ($stmt->affected_rows===0) {
-      $stmt2=$conn->prepare("INSERT INTO puntuaciones (estudiante_id, habilidad_id, puntaje) VALUES (?, ?, ?)");
-      $stmt2->bind_param("iii",$estudiante,$habilidad,$valor);
+      $stmt2=$conn->prepare("INSERT INTO puntuaciones (estudiante_id, actividad_id, habilidad_id, puntaje) VALUES (?, ?, ?, ?)");
+      $stmt2->bind_param("iiii",$estudiante,$actividad,$habilidad,$valor);
       $stmt2->execute();
     }
     $conn->commit();
   } catch(Exception $e){ $conn->rollback(); }
 }
-header("Location: puntuar_estudiante.php?id=".$estudiante);
+header("Location: puntuar_estudiante.php?id=".$estudiante."&actividad_id=".$actividad);
 exit;


### PR DESCRIPTION
## Summary
- allow selecting existing students when creating or editing an actividad and persist the many-to-many relationship
- migrate student management, scoring flows, and student views to support participation in multiple actividades with per-activity scores
- enable docentes to answer student feedback directly from the reto detail page with optional attachments

## Testing
- php -l actividades.php estudiantes.php login_estudiante.php perfil_estudiante.php puntuar.php puntuar_estudiante.php reto_detalle.php reto_estudiante.php update_puntaje.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ba4e8de8832694c7c7c68804a865